### PR TITLE
ci: ignore legacy commit in commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,20 @@
+name: Commit Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Lint commits
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: ./commitlint.config.mjs

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,4 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+  ignores: [(message) => message.trim() === 'Initial plan'],
+};


### PR DESCRIPTION
Adds commitlint config and workflow, ignoring the legacy 'Initial plan' commit while enforcing Conventional Commits.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test updates
- [x] Build/CI updates

## Changes Made

<!-- List the specific changes made in this PR -->

- add commitlint config files
- 
- 

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [x] I have tested these changes locally
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->
