### PR TITLE
feat: Overhaul with more specific logging and auth workflow validation, deduplication, codebase consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.5.1] - 2026-02-14
+
+### Fixed
+
+- Remove duplicate authentication settings UI by keeping auth inputs only in custom UI and removing credential/code fields from `config.schema.json`.
+- Align token persistence to a single auth state file so custom UI login persists across restarts without requiring credentials in `config.json`.
+- Harden custom UI auth logging/validation to reduce risk of secret leakage.
+
+### Added
+
+- Regression test to prevent reintroducing schema credential fields while custom UI auth is enabled.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Restart Homebridge after installing.
 
 The plugin provides a full configuration UI. Navigate to Plugins → Settings for @sealad886/homebridge-blink-cameras-new-api.
 
+Authentication is handled exclusively in the custom UI card (**Sign in to Blink**). The schema form intentionally does not expose credential or verification code fields.
+
 ### Manual Configuration
 
 Add a platform entry to your Homebridge `config.json`:
@@ -81,8 +83,6 @@ Add a platform entry to your Homebridge `config.json`:
     {
       "platform": "BlinkCameras",
       "name": "Blink",
-      "username": "you@example.com",
-      "password": "your-blink-password",
       "deviceId": "homebridge-blink-01",
       "persistAuth": true,
       "trustDevice": true,
@@ -103,13 +103,10 @@ Add a platform entry to your Homebridge `config.json`:
 | ------ | -------- | ------- | ----------- |
 | `platform` | Yes | - | Must be `BlinkCameras` |
 | `name` | Yes | `Blink` | Platform name shown in logs |
-| `username` | Yes | - | Your Blink account email |
-| `password` | Yes | - | Your Blink account password |
+| `username` | No* | - | Blink account email (legacy/manual auth fallback) |
+| `password` | No* | - | Blink account password (legacy/manual auth fallback) |
 | `deviceId` | No | `homebridge-blink` | Unique identifier sent to Blink (hardware_id) |
 | `deviceName` | No | - | Fallback for deviceId |
-| `twoFactorCode` | No | - | 2FA code (only needed during initial setup) |
-| `clientVerificationCode` | No | - | New-device verification PIN (only when prompted) |
-| `accountVerificationCode` | No | - | Account/phone verification PIN (only when prompted) |
 | `persistAuth` | No | `true` | Persist auth tokens across restarts |
 | `trustDevice` | No | `true` | Trust this device during client verification |
 | `tier` | No | `prod` | Blink API tier: `prod`, `sqa1`, `cemp`, `prde`, `prsg`, `a001`, or `srf1` (auto-detected tiers from Blink are honored for routing) |
@@ -138,21 +135,38 @@ When `persistAuth` is enabled, auth tokens are stored in a sibling folder to Hom
 storage (for example, `/var/lib/homebridge/blink-auth/`) to avoid corrupting the HAP
 persist directory.
 
+\* `username` and `password` are only needed for non-UI/manual fallback flows. In normal Homebridge UI usage, authenticate via the custom UI and keep credentials out of `config.json`.
+
 ## Quick Start: Login & Authorization
 
-On first setup, Blink may prompt for up to three codes. Provide only the one being requested at the time, then remove it after successful login/verification. Keep `persistAuth: true` so you won’t be prompted again.
+Use Homebridge UI → plugin Settings → **Sign in to Blink**.
 
-1. Start with your `username`, `password`, unique `deviceId`, and `persistAuth: true`.
-2. If prompted for a two-factor code, set `twoFactorCode` temporarily and restart Homebridge.
-3. If prompted for client verification (new device approval), set `clientVerificationCode` temporarily and restart.
-4. If prompted for account/phone verification, set `accountVerificationCode` temporarily and restart.
-5. After successful login/verification, remove any `*Code` values from your config and restart Homebridge.
+1. Enter email/password in the custom UI login card.
+2. Complete any prompted 2FA/client/account verification in the same custom UI flow.
+3. Keep `persistAuth: true` so tokens survive restarts.
+4. Confirm your `config.json` contains no password or verification codes.
 
 Tips:
 
 - Ensure `deviceId` is unique per Homebridge instance.
 - Leave `trustDevice: true` so future sessions are approved automatically.
 - If you keep seeing verification prompts, confirm that `persistAuth` is enabled and the Homebridge process can write to the auth directory.
+
+## Re-Authentication / Token Reset
+
+If you need to re-authenticate or switch Blink accounts:
+
+1. Stop Homebridge.
+2. Remove the persisted auth file in your Homebridge data directory sibling path: `blink-auth/auth-state.json`.
+3. Start Homebridge and run **Sign in to Blink** again from the plugin custom UI.
+
+## Manual Smoke Checklist (Duplicate Auth UI Regression)
+
+- Open Homebridge UI → Plugins → this plugin → Settings.
+- Confirm there is exactly one auth flow: the custom UI **Sign in to Blink** card.
+- Confirm there is no schema auth fieldset containing username/password/verification code inputs.
+- Complete login and restart Homebridge.
+- Confirm authentication persists and `config.json` has no password or verification code fields.
 
 ## Live Streaming (FFmpeg)
 

--- a/__tests__/platform.test.ts
+++ b/__tests__/platform.test.ts
@@ -3,6 +3,7 @@ import { BlinkCamerasPlatform } from '../src/platform';
 import { BlinkApi } from '../src/blink-api';
 import { createApi, createLogger } from './helpers/homebridge';
 import { BlinkHomescreen } from '../src/types';
+import { NetworkAccessory } from '../src/accessories';
 
 jest.mock('../src/blink-api');
 
@@ -100,7 +101,8 @@ describe('BlinkCamerasPlatform', () => {
     );
     platform.accessories.push(cachedAccessory);
 
-    (platform as unknown as { registerNetwork: (net: typeof network) => void }).registerNetwork(network);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (platform as any).registerDevice(network, 'blink-network-', 'network', (platform as any).networkAccessories, NetworkAccessory);
 
     expect(hapApi.registerPlatformAccessories).not.toHaveBeenCalled();
     // Handler is stored in Map, not in context (to avoid circular JSON serialization)

--- a/__tests__/schema-auth-ui.test.ts
+++ b/__tests__/schema-auth-ui.test.ts
@@ -50,6 +50,39 @@ const findLayoutKeyReferences = (node: unknown, targetKeys: Set<string>, hits: s
   return hits;
 };
 
+const collectAllLayoutKeys = (node: unknown, keys: string[] = []): string[] => {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectAllLayoutKeys(item, keys);
+    }
+    return keys;
+  }
+
+  if (typeof node === 'string') {
+    // extract the top-level property key (strip array indexing and nested paths)
+    const baseKey = node.split(/[.[]/)[0];
+    keys.push(baseKey);
+    return keys;
+  }
+
+  if (node && typeof node === 'object') {
+    const record = node as Record<string, unknown>;
+    if (typeof record.key === 'string') {
+      const baseKey = record.key.split(/[.[]/)[0];
+      keys.push(baseKey);
+      // skip nested items for array-type elements to avoid counting child paths as duplicates
+      if (record.type === 'array') {
+        return keys;
+      }
+    }
+    if (record.items) {
+      collectAllLayoutKeys(record.items, keys);
+    }
+  }
+
+  return keys;
+};
+
 describe('schema auth UI regression', () => {
   it('keeps custom UI enabled in package and schema metadata', () => {
     const pkg = readJson<PackageDocument>('package.json');
@@ -80,5 +113,57 @@ describe('schema auth UI regression', () => {
 
     const layoutReferences = findLayoutKeyReferences(schema.layout ?? [], forbiddenFields);
     expect(layoutReferences).toEqual([]);
+  });
+});
+
+describe('schema layout integrity', () => {
+  it('does not duplicate any field across layout sections', () => {
+    const schema = readJson<SchemaDocument>('config.schema.json');
+    const layout = schema.layout as Array<{ items?: unknown[] }>;
+    const allKeys: string[] = [];
+
+    for (const section of layout) {
+      if (section.items) {
+        collectAllLayoutKeys(section.items, allKeys);
+      }
+    }
+
+    const seen = new Set<string>();
+    const duplicates: string[] = [];
+    for (const key of allKeys) {
+      if (seen.has(key)) {
+        duplicates.push(key);
+      }
+      seen.add(key);
+    }
+    expect(duplicates).toEqual([]);
+  });
+
+  it('does not expose sharedTier in schema properties or layout', () => {
+    const schema = readJson<SchemaDocument>('config.schema.json');
+    const properties = schema.schema?.properties ?? {};
+
+    expect(Object.prototype.hasOwnProperty.call(properties, 'sharedTier')).toBe(false);
+
+    const hits = findLayoutKeyReferences(schema.layout ?? [], new Set(['sharedTier']));
+    expect(hits).toEqual([]);
+  });
+
+  it('uses array-based device customization instead of object additionalProperties', () => {
+    const schema = readJson<SchemaDocument>('config.schema.json');
+    const properties = schema.schema?.properties ?? {};
+
+    // Old object-based patterns must not appear
+    expect(Object.prototype.hasOwnProperty.call(properties, 'deviceNames')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(properties, 'deviceSettings')).toBe(false);
+
+    // New array-based patterns must exist
+    expect(Object.prototype.hasOwnProperty.call(properties, 'deviceNameOverrides')).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(properties, 'deviceSettingOverrides')).toBe(true);
+
+    const nameOverrides = properties.deviceNameOverrides as Record<string, unknown>;
+    const settingOverrides = properties.deviceSettingOverrides as Record<string, unknown>;
+    expect(nameOverrides.type).toBe('array');
+    expect(settingOverrides.type).toBe('array');
   });
 });

--- a/__tests__/schema-auth-ui.test.ts
+++ b/__tests__/schema-auth-ui.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+type SchemaDocument = {
+  customUi?: boolean;
+  customUiPath?: string;
+  schema?: {
+    properties?: Record<string, unknown>;
+  };
+  layout?: Array<unknown>;
+};
+
+type PackageDocument = {
+  homebridge?: {
+    schema?: string;
+    customUi?: string;
+  };
+};
+
+const repoRoot = path.resolve('.');
+
+const readJson = <T>(relativePath: string): T => {
+  const absolutePath = path.join(repoRoot, relativePath);
+  return JSON.parse(fs.readFileSync(absolutePath, 'utf8')) as T;
+};
+
+const findLayoutKeyReferences = (node: unknown, targetKeys: Set<string>, hits: string[] = []): string[] => {
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      findLayoutKeyReferences(item, targetKeys, hits);
+    }
+    return hits;
+  }
+
+  if (typeof node === 'string' && targetKeys.has(node)) {
+    hits.push(node);
+    return hits;
+  }
+
+  if (node && typeof node === 'object') {
+    const record = node as Record<string, unknown>;
+    if (typeof record.key === 'string' && targetKeys.has(record.key)) {
+      hits.push(record.key);
+    }
+    for (const value of Object.values(record)) {
+      findLayoutKeyReferences(value, targetKeys, hits);
+    }
+  }
+
+  return hits;
+};
+
+describe('schema auth UI regression', () => {
+  it('keeps custom UI enabled in package and schema metadata', () => {
+    const pkg = readJson<PackageDocument>('package.json');
+    const schema = readJson<SchemaDocument>('config.schema.json');
+
+    expect(pkg.homebridge?.schema).toBe('config.schema.json');
+    expect(pkg.homebridge?.customUi).toBe('dist/homebridge-ui/server.js');
+    expect(schema.customUi).toBe(true);
+    expect(schema.customUiPath).toBe('./dist/homebridge-ui');
+  });
+
+  it('does not expose auth credentials/codes in schema properties or layout', () => {
+    const schema = readJson<SchemaDocument>('config.schema.json');
+    const properties = schema.schema?.properties ?? {};
+
+    const forbiddenFields = new Set([
+      'username',
+      'email',
+      'password',
+      'twoFactorCode',
+      'clientVerificationCode',
+      'accountVerificationCode',
+    ]);
+
+    for (const key of forbiddenFields) {
+      expect(Object.prototype.hasOwnProperty.call(properties, key)).toBe(false);
+    }
+
+    const layoutReferences = findLayoutKeyReferences(schema.layout ?? [], forbiddenFields);
+    expect(layoutReferences).toEqual([]);
+  });
+});

--- a/blink_api_map.md
+++ b/blink_api_map.md
@@ -323,11 +323,11 @@ Poll this endpoint every `polling_interval` seconds to check if the live view se
 - `"complete"` - Stream ended normally
 - `"failed"` - Stream failed to start
 
-### Extending Live View Session
+### Live View Session Monitoring
 
-**Endpoint:** `POST /accounts/{account}/networks/{network}/commands/{command_id}/update`
+Use command polling (`GET /accounts/{account}/networks/{network}/commands/{command_id}`) to monitor whether the session is still running.
 
-Call this before the session times out to extend it.
+`POST /accounts/{account}/networks/{network}/commands/{command_id}/update` is currently treated as onboarding/status update behavior and should not be assumed to extend live view sessions.
 
 [CameraApi](jadx-out/sources/com/immediasemi/blink/common/device/camera/CameraApi.java) / [DoorbellApi](jadx-out/sources/com/immediasemi/blink/common/device/camera/doorbell/DoorbellApi.java) / [OwlApi](jadx-out/sources/com/immediasemi/blink/common/device/camera/wired/OwlApi.java) / [LiveViewCommandPostBody](jadx-out/sources/com/immediasemi/blink/common/device/camera/video/live/LiveViewCommandPostBody.java) / [LiveViewCommandResponse](jadx-out/sources/com/immediasemi/blink/common/device/camera/video/live/LiveViewCommandResponse.java)
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,19 +16,6 @@
         "default": "Blink",
         "required": true
       },
-      "username": {
-        "title": "Blink Account Email",
-        "description": "Your Blink account email address",
-        "type": "string",
-        "format": "email",
-        "required": true
-      },
-      "password": {
-        "title": "Blink Account Password",
-        "description": "Your Blink account password",
-        "type": "string",
-        "required": true
-      },
       "deviceId": {
         "title": "Device ID",
         "description": "Unique identifier for this Homebridge instance (sent to Blink as hardware_id)",
@@ -39,24 +26,6 @@
       "deviceName": {
         "title": "Device Name",
         "description": "Friendly name for this device (fallback for Device ID)",
-        "type": "string",
-        "required": false
-      },
-      "twoFactorCode": {
-        "title": "Two-Factor Code",
-        "description": "2FA code for initial login. Only needed if Blink sends a verification code. Remove after successful login.",
-        "type": "string",
-        "required": false
-      },
-      "clientVerificationCode": {
-        "title": "Client Verification Code",
-        "description": "Verification code sent for new device approval. Only needed if Blink asks to verify this client. Remove after successful verification.",
-        "type": "string",
-        "required": false
-      },
-      "accountVerificationCode": {
-        "title": "Account Verification Code",
-        "description": "Verification code sent for account/phone verification. Only needed if Blink requests account verification. Remove after successful verification.",
         "type": "string",
         "required": false
       },
@@ -296,16 +265,15 @@
   "layout": [
     {
       "type": "fieldset",
-      "title": "Account Settings",
+      "title": "Platform Settings",
       "items": [
         "name",
-        "username",
-        {
-          "key": "password",
-          "type": "password"
-        },
-        "twoFactorCode",
-        "clientVerificationCode"
+        "tier",
+        "sharedTier",
+        "persistAuth",
+        "trustDevice",
+        "authLocked",
+        "debugAuth"
       ]
     },
     {

--- a/config.schema.json
+++ b/config.schema.json
@@ -104,6 +104,13 @@
         "default": false,
         "required": false
       },
+      "authLocked": {
+        "title": "Lock Authentication",
+        "description": "Lock authentication state after successful login. When locked, stored 2FA and verification codes in the config are ignored and only token refresh is used. Unlock to force re-authentication.",
+        "type": "boolean",
+        "default": false,
+        "required": false
+      },
       "persistAuth": {
         "title": "Persist Auth Tokens",
         "description": "Persist OAuth tokens across restarts to avoid repeated logins and verification prompts.",
@@ -362,6 +369,7 @@
       "items": [
         "tier",
         "debugAuth",
+        "authLocked",
         "persistAuth",
         "trustDevice"
       ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -30,55 +30,23 @@
         "required": false
       },
       "tier": {
-        "title": "Blink Environment",
-        "description": "Blink API environment tier. Use 'prod' for production (default). Numeric tiers like 'e006' are region-specific production endpoints.",
+        "title": "Blink Region",
+        "description": "Blink API region. Use 'Production' for most users. The plugin auto-discovers the correct endpoint after first login.",
         "type": "string",
         "default": "prod",
         "required": false,
         "oneOf": [
-          { "title": "Production", "enum": ["prod"] },
+          { "title": "Production (Default)", "enum": ["prod"] },
+          { "title": "Europe (EU)", "enum": ["prde"] },
+          { "title": "Asia Pacific (APAC)", "enum": ["prsg"] },
+          { "title": "Australia (AU)", "enum": ["a001"] },
           { "title": "Production (e001)", "enum": ["e001"] },
           { "title": "Production (e002)", "enum": ["e002"] },
           { "title": "Production (e003)", "enum": ["e003"] },
           { "title": "Production (e004)", "enum": ["e004"] },
           { "title": "Production (e005)", "enum": ["e005"] },
-          { "title": "Production (e006)", "enum": ["e006"] },
-          { "title": "Staging (SQA1)", "enum": ["sqa1"] },
-          { "title": "CEMP", "enum": ["cemp"] },
-          { "title": "Production (EU)", "enum": ["prde"] },
-          { "title": "Production (APAC)", "enum": ["prsg"] },
-          { "title": "Production (AU)", "enum": ["a001"] },
-          { "title": "SRF1", "enum": ["srf1"] }
+          { "title": "Production (e006)", "enum": ["e006"] }
         ]
-      },
-      "sharedTier": {
-        "title": "Blink Shared Tier",
-        "description": "Override shared REST tier (rest-{shared_tier}); defaults to tier when unset.",
-        "type": "string",
-        "required": false,
-        "oneOf": [
-          { "title": "Production", "enum": ["prod"] },
-          { "title": "Staging (SQA1)", "enum": ["sqa1"] },
-          { "title": "CEMP", "enum": ["cemp"] },
-          { "title": "Production (EU)", "enum": ["prde"] },
-          { "title": "Production (APAC)", "enum": ["prsg"] },
-          { "title": "Production (AU)", "enum": ["a001"] },
-          { "title": "SRF1", "enum": ["srf1"] }
-        ]
-      },
-      "debugAuth": {
-        "title": "Debug Authentication",
-        "description": "Enable verbose diagnostic logging for Blink API authentication. Useful for troubleshooting login failures, token issues, and API errors. WARNING: May log sensitive request details.",
-        "type": "boolean",
-        "default": false,
-        "required": false
-      },
-      "authLocked": {
-        "title": "Lock Authentication",
-        "description": "Lock authentication state after successful login. When locked, stored 2FA and verification codes in the config are ignored and only token refresh is used. Unlock to force re-authentication.",
-        "type": "boolean",
-        "default": false,
-        "required": false
       },
       "persistAuth": {
         "title": "Persist Auth Tokens",
@@ -92,6 +60,20 @@
         "description": "Mark this Homebridge instance as a trusted device during client verification.",
         "type": "boolean",
         "default": true,
+        "required": false
+      },
+      "authLocked": {
+        "title": "Lock Authentication",
+        "description": "Lock authentication state after successful login. When locked, stored verification codes are ignored and only token refresh is used. Unlock to force re-authentication.",
+        "type": "boolean",
+        "default": false,
+        "required": false
+      },
+      "debugAuth": {
+        "title": "Debug Authentication",
+        "description": "Enable verbose diagnostic logging for Blink API authentication. WARNING: May log sensitive request details.",
+        "type": "boolean",
+        "default": false,
         "required": false
       },
       "pollInterval": {
@@ -119,6 +101,15 @@
         "default": true,
         "required": false
       },
+      "snapshotCacheTTL": {
+        "title": "Snapshot Cache Duration (seconds)",
+        "description": "How long to cache camera snapshots before requesting a fresh one from Blink. Set to 0 to always request fresh snapshots (uses more battery). Default: 60 seconds.",
+        "type": "integer",
+        "default": 60,
+        "minimum": 0,
+        "maximum": 300,
+        "required": false
+      },
       "enableStreaming": {
         "title": "Enable Live Streaming",
         "description": "Enable HomeKit live video streaming via FFmpeg.",
@@ -142,19 +133,10 @@
       },
       "debugStreamPath": {
         "title": "Debug Stream Recording Path",
-        "description": "Path to save raw MPEG-TS stream recordings for debugging. Leave empty to disable. Files are saved as blink-stream-{serial}-{timestamp}.ts",
+        "description": "Path to save raw MPEG-TS stream recordings for debugging. Leave empty to disable.",
         "type": "string",
         "required": false,
         "placeholder": "/tmp/blink-streams"
-      },
-      "snapshotCacheTTL": {
-        "title": "Snapshot Cache Duration (seconds)",
-        "description": "How long to cache camera snapshots before requesting a fresh one from Blink. Set to 0 to always request fresh snapshots (uses more battery). Default: 60 seconds.",
-        "type": "integer",
-        "default": 60,
-        "minimum": 0,
-        "maximum": 300,
-        "required": false
       },
       "rtspTransport": {
         "title": "RTSP Transport",
@@ -222,7 +204,7 @@
       },
       "excludeDevices": {
         "title": "Excluded Devices",
-        "description": "List of device serial numbers, IDs, or names to exclude from HomeKit. Useful for hiding devices you don't want to control.",
+        "description": "List of device serial numbers, IDs, or names to exclude from HomeKit.",
         "type": "array",
         "items": {
           "type": "string",
@@ -230,29 +212,51 @@
         },
         "required": false
       },
-      "deviceNames": {
+      "deviceNameOverrides": {
         "title": "Custom Device Names",
-        "description": "Override display names for devices in HomeKit. Key is the device serial number or ID, value is the custom name.",
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
+        "description": "Override display names for devices in HomeKit.",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "deviceIdentifier": {
+              "title": "Device Serial / ID",
+              "description": "The device serial number or numeric ID to rename",
+              "type": "string",
+              "required": true
+            },
+            "customName": {
+              "title": "Custom Name",
+              "description": "The display name to use in HomeKit",
+              "type": "string",
+              "required": true
+            }
+          }
         },
         "required": false
       },
-      "deviceSettings": {
+      "deviceSettingOverrides": {
         "title": "Per-Device Settings",
-        "description": "Override settings for specific devices. Key is the device serial number or ID.",
-        "type": "object",
-        "additionalProperties": {
+        "description": "Override settings for specific devices.",
+        "type": "array",
+        "items": {
           "type": "object",
           "properties": {
+            "deviceIdentifier": {
+              "title": "Device Serial / ID",
+              "description": "The device serial number or numeric ID to configure",
+              "type": "string",
+              "required": true
+            },
             "motionTimeout": {
+              "title": "Motion Timeout (seconds)",
               "type": "integer",
               "minimum": 5,
               "maximum": 300,
               "description": "Motion timeout in seconds for this device"
             },
             "enableMotion": {
+              "title": "Enable Motion Detection",
               "type": "boolean",
               "description": "Enable/disable motion detection for this device"
             }
@@ -268,12 +272,7 @@
       "title": "Platform Settings",
       "items": [
         "name",
-        "tier",
-        "sharedTier",
-        "persistAuth",
-        "trustDevice",
-        "authLocked",
-        "debugAuth"
+        "tier"
       ]
     },
     {
@@ -288,13 +287,14 @@
     },
     {
       "type": "fieldset",
-      "title": "Polling Settings",
+      "title": "Polling & Snapshots",
       "expandable": true,
       "expanded": false,
       "items": [
         "pollInterval",
         "motionTimeout",
-        "enableMotionPolling"
+        "enableMotionPolling",
+        "snapshotCacheTTL"
       ]
     },
     {
@@ -305,13 +305,15 @@
       "items": [
         "enableStreaming",
         "ffmpegPath",
-        "ffmpegDebug",
-        "rtspTransport",
         "maxStreams",
         "enableAudio",
+        "twoWayAudio",
         "audioCodec",
         "audioBitrate",
-        "videoBitrate"
+        "videoBitrate",
+        "rtspTransport",
+        "ffmpegDebug",
+        "debugStreamPath"
       ]
     },
     {
@@ -323,10 +325,30 @@
         {
           "key": "excludeDevices",
           "type": "array",
-          "buttonText": "Add Device to Exclude"
+          "buttonText": "Add Device to Exclude",
+          "items": [
+            "excludeDevices[]"
+          ]
         },
-        "deviceNames",
-        "deviceSettings"
+        {
+          "key": "deviceNameOverrides",
+          "type": "array",
+          "buttonText": "Add Name Override",
+          "items": [
+            "deviceNameOverrides[].deviceIdentifier",
+            "deviceNameOverrides[].customName"
+          ]
+        },
+        {
+          "key": "deviceSettingOverrides",
+          "type": "array",
+          "buttonText": "Add Device Setting",
+          "items": [
+            "deviceSettingOverrides[].deviceIdentifier",
+            "deviceSettingOverrides[].motionTimeout",
+            "deviceSettingOverrides[].enableMotion"
+          ]
+        }
       ]
     },
     {
@@ -335,11 +357,10 @@
       "expandable": true,
       "expanded": false,
       "items": [
-        "tier",
-        "debugAuth",
-        "authLocked",
         "persistAuth",
-        "trustDevice"
+        "trustDevice",
+        "authLocked",
+        "debugAuth"
       ]
     }
   ]

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -104,6 +104,31 @@
 - `package.json` (`copy-ui-assets` script)
 - `src/homebridge-ui/public/index.html`
 
+### Authentication UI Single Source of Truth
+
+**Status:** REQUIRED
+
+**Scope:** Homebridge settings UX and authentication configuration.
+
+**Rule:** When `homebridge.customUi` is enabled for this plugin, credential and verification-code inputs must exist only in the custom UI and must not be defined in `config.schema.json` properties/layout.
+
+**Rationale (Why this exists):**
+
+- Config UI X renders both schema fields and custom UI in plugin settings; defining auth fields in both creates duplicate and conflicting login flows.
+- Keeping credentials out of schema avoids persisting passwords and one-time verification codes in `config.json`.
+- Token persistence already exists via `blink-auth/auth-state.json`, so the custom UI can remain the single auth entry point.
+
+**Examples:**
+
+- Good: `config.schema.json` keeps non-secret platform settings only, while `src/homebridge-ui/public/index.html` contains the sign-in + verification workflow.
+- Bad: Reintroducing `username`, `password`, `twoFactorCode`, `clientVerificationCode`, or `accountVerificationCode` into schema properties or layout.
+
+**Related Files / Modules:**
+
+- `config.schema.json`
+- `homebridge-ui/public/index.html`
+- `src/homebridge-ui/server.ts`
+
 ## 3. Rationale and Examples
 
 - See individual conventions above.
@@ -114,6 +139,7 @@
 
 ## 5. Change History (Human-Readable)
 
+- 2026-02-14: Added required convention that auth credentials/codes must not be exposed in schema when custom UI auth is enabled.
 - 2026-01-20: Two-way talk is now forced off; HomeKit microphone UI is hidden and any config attempts log warnings.
 - 2026-01-17: Added convention clarifying npm registry requirement for publisher handle in Homebridge UI.
 - 2026-01-18: Added two-way talk status guardrails and experimental designation.

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -811,28 +811,15 @@
     showStep('login');
   });
 
-  // Check for existing auth on load
-  // Always start by checking auth status and showing appropriate UI
-  if (pluginConfig.length > 0 && pluginConfig[0].username) {
-    // Already configured - check auth status
-    const status = await refreshAuthStatus();
-    if (status?.authenticated) {
-      // Show success view with re-auth option, then show schema form
-      updateAccountDisplay(true, status);
-      showStep('success');
-      homebridge.showSchemaForm();
-    } else {
-      // Config exists but not authenticated - show login wizard for re-auth
-      showStep('login');
-    }
+  // Check auth status on load and drive UI from token state, not config fields.
+  const status = await refreshAuthStatus();
+  if (status?.authenticated) {
+    savedUsername = resolveUsername(status) || 'Unknown';
+    savedTier = resolveTier(status) || document.getElementById('tier').value;
+    handleAuthSuccess(status);
   } else {
-    // No config yet - user needs to authenticate first
-    const status = await refreshAuthStatus();
-    if (status?.authenticated) {
-      savedUsername = resolveUsername(status) || 'Unknown';
-      savedTier = resolveTier(status) || document.getElementById('tier').value;
-      handleAuthSuccess(status);
-    }
+    homebridge.hideSchemaForm();
+    showStep('login');
   }
 })();
 </script>

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -324,9 +324,14 @@
           <p class="text-muted small">
             Your credentials have been saved. You can now configure your camera settings below.
           </p>
-          <button type="button" class="btn btn-outline-primary" id="showSchemaForm">
-            Configure Camera Settings
-          </button>
+          <div class="btn-group-vertical">
+            <button type="button" class="btn btn-outline-primary" id="showSchemaForm">
+              Configure Camera Settings
+            </button>
+            <button type="button" class="btn btn-outline-secondary btn-sm mt-2" id="reAuthBtn">
+              Re-authenticate / Enter Verification Code
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -780,15 +785,32 @@
     }
   });
 
+  // Re-authenticate button - takes user back to login wizard
+  document.getElementById('reAuthBtn').addEventListener('click', async () => {
+    // Clear server-side auth state so we get a fresh login
+    try {
+      await homebridge.request('/logout');
+    } catch {
+      // ignore errors - just proceed to login
+    }
+    homebridge.hideSchemaForm();
+    showStep('login');
+  });
+
   // Check for existing auth on load
-  // If already configured (has username), show schema form immediately
-  // The login wizard is only needed for initial setup or re-authentication
+  // Always start by checking auth status and showing appropriate UI
   if (pluginConfig.length > 0 && pluginConfig[0].username) {
-    // Already configured - show schema form by default
-    homebridge.showSchemaForm();
-    
-    // Also check auth status to show appropriate UI state
-    await refreshAuthStatus();
+    // Already configured - check auth status
+    const status = await refreshAuthStatus();
+    if (status?.authenticated) {
+      // Show success view with re-auth option, then show schema form
+      updateAccountDisplay(true, status);
+      showStep('success');
+      homebridge.showSchemaForm();
+    } else {
+      // Config exists but not authenticated - show login wizard for re-auth
+      showStep('login');
+    }
   } else {
     // No config yet - user needs to authenticate first
     const status = await refreshAuthStatus();

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -550,6 +550,12 @@
         savedUsername = resolveUsername(status);
         savedTier = resolveTier(status);
         showStep('success');
+      } else if (status?.requires2FA) {
+        handleVerificationRequired('2fa', status);
+      } else if (status?.requiresClientVerification) {
+        handleVerificationRequired('client', status);
+      } else if (status?.requiresAccountVerification) {
+        handleVerificationRequired('account', status);
       }
       return status;
     } catch (e) {
@@ -635,8 +641,13 @@
 
       if (response.authenticated) {
         handleAuthSuccess(response);
+      } else if (response.requires2FA) {
+        handleVerificationRequired('2fa', response);
+      } else if (response.requiresClientVerification) {
+        handleVerificationRequired('client', response);
+      } else if (response.requiresAccountVerification) {
+        handleVerificationRequired('account', response);
       }
-      // Other cases handled via events
     } catch (e) {
       showError(e.message || 'Login failed');
     } finally {
@@ -667,8 +678,11 @@
 
       if (response.authenticated) {
         handleAuthSuccess(response);
+      } else if (response.requiresClientVerification) {
+        handleVerificationRequired('client', response);
+      } else if (response.requiresAccountVerification) {
+        handleVerificationRequired('account', response);
       }
-      // Other cases handled via events
     } catch (e) {
       showError(e.message || 'Verification failed');
     } finally {
@@ -767,7 +781,7 @@
 
     showStep('success');
     homebridge.toast.success('Successfully authenticated with Blink!', 'Success');
-    
+
     // Automatically show the schema form after successful auth so user can configure all settings
     homebridge.showSchemaForm();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
-    "version": "0.4.7",
+    "version": "0.5.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@sealad886/homebridge-blink-cameras-new-api",
-            "version": "0.4.7",
+            "version": "0.5.6",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.4.10",
+    "version": "0.5.0",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@sealad886/homebridge-blink-cameras-new-api",
     "displayName": "Homebridge Blink Cameras (New API)",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "description": "Blink Camera plugin for homebridge",
     "author": {
         "name": "sealad886",

--- a/src/accessories/camera.ts
+++ b/src/accessories/camera.ts
@@ -10,172 +10,29 @@
  * Evidence: smali_classes9/com/immediasemi/blink/common/device/camera/CameraApi.smali
  */
 
-import { CameraController, CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { PlatformAccessory } from 'homebridge';
 import { BlinkCamerasPlatform } from '../platform';
 import { BlinkCamera } from '../types';
-import { setTimeout, clearTimeout } from 'timers';
-import { BlinkCameraSource, createCameraControllerOptions } from './camera-source';
+import { MotionDeviceBase } from './motion-base';
 
-export class CameraAccessory {
-  private readonly switchService: Service;
-  private readonly motionService: Service;
-  private readonly cameraController: CameraController;
-  private motionDetected = false;
-  private motionTimeout: ReturnType<typeof setTimeout> | null = null;
-
+export class CameraAccessory extends MotionDeviceBase<BlinkCamera> {
   constructor(
-    private readonly platform: BlinkCamerasPlatform,
-    private readonly accessory: PlatformAccessory,
-    private device: BlinkCamera,
+    platform: BlinkCamerasPlatform,
+    accessory: PlatformAccessory,
+    device: BlinkCamera,
   ) {
-    // Configure accessory information
-    this.accessory.getService(this.platform.Service.AccessoryInformation)
-      ?.setCharacteristic(this.platform.Characteristic.Manufacturer, 'Blink')
-      .setCharacteristic(this.platform.Characteristic.Model, device.type ?? 'Camera')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, device.serial ?? `${device.id}`);
-
-    // Switch service for motion detection enable/disable
-    this.switchService =
-      this.accessory.getService(this.platform.Service.Switch) ||
-      this.accessory.addService(this.platform.Service.Switch, `${device.name} Motion`, 'motion-switch');
-
-    this.switchService
-      .getCharacteristic(this.platform.Characteristic.On)
-      .onGet(() => this.device.enabled)
-      .onSet(async (value) => this.setMotionEnabled(value));
-
-    // MotionSensor service for motion detection events
-    this.motionService =
-      this.accessory.getService(this.platform.Service.MotionSensor) ||
-      this.accessory.addService(this.platform.Service.MotionSensor, device.name, 'motion-sensor');
-
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.MotionDetected)
-      .onGet(() => this.motionDetected);
-
-    // StatusActive indicates if the sensor is operational (motion enabled)
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.StatusActive)
-      .onGet(() => this.device.enabled);
-
-    // Camera controller for snapshot support
-    // Determine device type from API response - Mini cameras have type 'owl'
-    // and require different API endpoints even when returned in cameras array
-    const deviceType = device.type === 'owl' ? 'owl' : 'camera';
-    this.platform.log.debug(`[${device.name}] Camera type detection: device.type='${device.type}', using deviceType='${deviceType}'`);
-
-    const cameraSource = new BlinkCameraSource(
-      this.platform.apiClient,
-      this.platform.api.hap,
-      device.network_id,
-      device.id,
-      deviceType,
-      device.serial ?? `${device.id}`,
-      () => this.device.thumbnail,
-      (msg) => this.platform.log.debug(`[${device.name}] ${msg}`),
-      this.platform.streamingConfig,
+    const deviceType = device.type === 'owl' ? 'owl' as const : 'camera' as const;
+    super(platform, accessory, device, device.type ?? 'Camera', 'camera', deviceType);
+    platform.log.debug(
+      `[${device.name}] Camera type detection: device.type='${device.type}', using deviceType='${deviceType}'`,
     );
-
-    this.cameraController = new this.platform.api.hap.CameraController(
-      createCameraControllerOptions(this.platform.api.hap, cameraSource, this.platform.streamingConfig),
-    );
-    this.accessory.configureController(this.cameraController);
   }
 
-  /**
-   * Enable or disable motion detection
-   * Source: API Dossier Section 3.3 - enable/disable endpoints
-   */
-  private async setMotionEnabled(value: CharacteristicValue): Promise<void> {
-    const target = Boolean(value);
-
-    if (target === this.device.enabled) {
-      return;
-    }
-
-    try {
-      if (target) {
-        await this.platform.apiClient.enableCameraMotion(this.device.network_id, this.device.id);
-        this.platform.log.info(`Enabled motion detection for camera: ${this.device.name}`);
-      } else {
-        await this.platform.apiClient.disableCameraMotion(this.device.network_id, this.device.id);
-        this.platform.log.info(`Disabled motion detection for camera: ${this.device.name}`);
-      }
-
-      this.device.enabled = target;
-      this.accessory.context.device = this.device;
-
-      // Update motion sensor StatusActive
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(target);
-    } catch (error) {
-      this.platform.log.error(`Failed to ${target ? 'enable' : 'disable'} motion for camera ${this.device.name}:`, error);
-      throw error;
-    }
+  protected async enableMotionApi(): Promise<void> {
+    await this.platform.apiClient.enableCameraMotion(this.device.network_id, this.device.id);
   }
 
-  /**
-   * Update device state from polling.
-   * Called by platform when homescreen data is refreshed.
-   * Updates Switch and StatusActive characteristics if enabled state changed.
-   *
-   * @param device - Fresh device data from Blink API homescreen response
-   */
-  updateState(device: BlinkCamera): void {
-    const previousEnabled = this.device.enabled;
-    this.device = device;
-    this.accessory.context.device = device;
-
-    if (previousEnabled !== device.enabled) {
-      this.switchService
-        .getCharacteristic(this.platform.Characteristic.On)
-        .updateValue(device.enabled);
-
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(device.enabled);
-
-      this.platform.log.debug(
-        `Camera ${device.name} motion detection: ${device.enabled ? 'enabled' : 'disabled'}`,
-      );
-    }
-  }
-
-  /**
-   * Trigger motion detected event.
-   * Called when a new motion clip is detected for this camera.
-   * Sets MotionDetected characteristic to true, then auto-resets after timeout.
-   *
-   * @param timeoutMs - Duration in milliseconds before resetting motion state (default 30000)
-   */
-  triggerMotion(timeoutMs = 30000): void {
-    if (this.motionTimeout) {
-      clearTimeout(this.motionTimeout);
-    }
-
-    this.motionDetected = true;
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.MotionDetected)
-      .updateValue(true);
-
-    this.platform.log.info(`Motion detected on camera: ${this.device.name}`);
-
-    this.motionTimeout = setTimeout(() => {
-      this.motionDetected = false;
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.MotionDetected)
-        .updateValue(false);
-      this.motionTimeout = null;
-    }, timeoutMs);
-  }
-
-  /**
-   * Get the camera ID for matching with media clips.
-   *
-   * @returns The Blink camera ID
-   */
-  getCameraId(): number {
-    return this.device.id;
+  protected async disableMotionApi(): Promise<void> {
+    await this.platform.apiClient.disableCameraMotion(this.device.network_id, this.device.id);
   }
 }

--- a/src/accessories/doorbell.ts
+++ b/src/accessories/doorbell.ts
@@ -11,147 +11,38 @@
  * Evidence: smali_classes9/com/immediasemi/blink/common/device/camera/doorbell/DoorbellApi.smali
  */
 
-import { CameraController, CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { PlatformAccessory, Service } from 'homebridge';
 import { BlinkCamerasPlatform } from '../platform';
 import { BlinkDoorbell } from '../types';
-import { setTimeout, clearTimeout } from 'timers';
-import { BlinkCameraSource, createCameraControllerOptions } from './camera-source';
+import { MotionDeviceBase } from './motion-base';
 
-export class DoorbellAccessory {
+export class DoorbellAccessory extends MotionDeviceBase<BlinkDoorbell> {
   private readonly doorbellService: Service;
-  private readonly switchService: Service;
-  private readonly motionService: Service;
-  private readonly cameraController: CameraController;
-  private motionDetected = false;
-  private motionTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
-    private readonly platform: BlinkCamerasPlatform,
-    private readonly accessory: PlatformAccessory,
-    private device: BlinkDoorbell,
+    platform: BlinkCamerasPlatform,
+    accessory: PlatformAccessory,
+    device: BlinkDoorbell,
   ) {
-    // Configure accessory information
-    this.accessory.getService(this.platform.Service.AccessoryInformation)
-      ?.setCharacteristic(this.platform.Characteristic.Manufacturer, 'Blink')
-      .setCharacteristic(this.platform.Characteristic.Model, 'Doorbell')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, device.serial ?? `${device.id}`);
+    super(platform, accessory, device, 'Doorbell', 'doorbell', 'doorbell', `${device.name} Motion`);
 
-    // Doorbell service for ring notifications
     this.doorbellService =
       this.accessory.getService(this.platform.Service.Doorbell) ||
       this.accessory.addService(this.platform.Service.Doorbell, device.name, 'doorbell');
 
-    // ProgrammableSwitchEvent is used to trigger doorbell ring
     this.doorbellService
       .getCharacteristic(this.platform.Characteristic.ProgrammableSwitchEvent)
       .setProps({ maxValue: 0, minValue: 0, validValues: [0] });
-
-    // Switch service for motion detection enable/disable
-    this.switchService =
-      this.accessory.getService(this.platform.Service.Switch) ||
-      this.accessory.addService(this.platform.Service.Switch, `${device.name} Motion`, 'motion-switch');
-
-    this.switchService
-      .getCharacteristic(this.platform.Characteristic.On)
-      .onGet(() => this.device.enabled)
-      .onSet(async (value) => this.setMotionEnabled(value));
-
-    // MotionSensor service for motion detection events
-    this.motionService =
-      this.accessory.getService(this.platform.Service.MotionSensor) ||
-      this.accessory.addService(this.platform.Service.MotionSensor, `${device.name} Motion`, 'motion-sensor');
-
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.MotionDetected)
-      .onGet(() => this.motionDetected);
-
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.StatusActive)
-      .onGet(() => this.device.enabled);
-
-    // Camera controller for snapshot support
-    const cameraSource = new BlinkCameraSource(
-      this.platform.apiClient,
-      this.platform.api.hap,
-      device.network_id,
-      device.id,
-      'doorbell',
-      device.serial ?? `${device.id}`,
-      () => this.device.thumbnail,
-      (msg) => this.platform.log.debug(`[${device.name}] ${msg}`),
-      this.platform.streamingConfig,
-    );
-
-    this.cameraController = new this.platform.api.hap.CameraController(
-      createCameraControllerOptions(this.platform.api.hap, cameraSource, this.platform.streamingConfig),
-    );
-    this.accessory.configureController(this.cameraController);
   }
 
-  /**
-   * Enable or disable motion detection
-   * Source: API Dossier Section 3.5 - enable/disable endpoints
-   */
-  private async setMotionEnabled(value: CharacteristicValue): Promise<void> {
-    const target = Boolean(value);
-
-    if (target === this.device.enabled) {
-      return;
-    }
-
-    try {
-      if (target) {
-        await this.platform.apiClient.enableDoorbellMotion(this.device.network_id, this.device.id);
-        this.platform.log.info(`Enabled motion detection for doorbell: ${this.device.name}`);
-      } else {
-        await this.platform.apiClient.disableDoorbellMotion(this.device.network_id, this.device.id);
-        this.platform.log.info(`Disabled motion detection for doorbell: ${this.device.name}`);
-      }
-
-      this.device.enabled = target;
-      this.accessory.context.device = this.device;
-
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(target);
-    } catch (error) {
-      this.platform.log.error(`Failed to ${target ? 'enable' : 'disable'} motion for doorbell ${this.device.name}:`, error);
-      throw error;
-    }
+  protected async enableMotionApi(): Promise<void> {
+    await this.platform.apiClient.enableDoorbellMotion(this.device.network_id, this.device.id);
   }
 
-  /**
-   * Update device state from polling.
-   * Called by platform when homescreen data is refreshed.
-   * Updates Switch and StatusActive characteristics if enabled state changed.
-   *
-   * @param device - Fresh device data from Blink API homescreen response
-   */
-  updateState(device: BlinkDoorbell): void {
-    const previousEnabled = this.device.enabled;
-    this.device = device;
-    this.accessory.context.device = device;
-
-    if (previousEnabled !== device.enabled) {
-      this.switchService
-        .getCharacteristic(this.platform.Characteristic.On)
-        .updateValue(device.enabled);
-
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(device.enabled);
-
-      this.platform.log.debug(
-        `Doorbell ${device.name} motion detection: ${device.enabled ? 'enabled' : 'disabled'}`,
-      );
-    }
+  protected async disableMotionApi(): Promise<void> {
+    await this.platform.apiClient.disableDoorbellMotion(this.device.network_id, this.device.id);
   }
 
-  /**
-   * Trigger doorbell ring event.
-   * Sends ProgrammableSwitchEvent.SINGLE_PRESS to HomeKit.
-   * Called when a doorbell press is detected in media polling.
-   */
   triggerRing(): void {
     const { ProgrammableSwitchEvent } = this.platform.Characteristic;
 
@@ -160,42 +51,5 @@ export class DoorbellAccessory {
       .updateValue(ProgrammableSwitchEvent.SINGLE_PRESS);
 
     this.platform.log.info(`Doorbell ring: ${this.device.name}`);
-  }
-
-  /**
-   * Trigger motion detected event.
-   * Called when a new motion clip is detected for this doorbell.
-   * Sets MotionDetected characteristic to true, then auto-resets after timeout.
-   *
-   * @param timeoutMs - Duration in milliseconds before resetting motion state (default 30000)
-   */
-  triggerMotion(timeoutMs = 30000): void {
-    if (this.motionTimeout) {
-      clearTimeout(this.motionTimeout);
-    }
-
-    this.motionDetected = true;
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.MotionDetected)
-      .updateValue(true);
-
-    this.platform.log.info(`Motion detected on doorbell: ${this.device.name}`);
-
-    this.motionTimeout = setTimeout(() => {
-      this.motionDetected = false;
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.MotionDetected)
-        .updateValue(false);
-      this.motionTimeout = null;
-    }, timeoutMs);
-  }
-
-  /**
-   * Get the doorbell ID for matching with media clips.
-   *
-   * @returns The Blink doorbell ID
-   */
-  getDoorbellId(): number {
-    return this.device.id;
   }
 }

--- a/src/accessories/index.ts
+++ b/src/accessories/index.ts
@@ -1,4 +1,6 @@
 export { CameraAccessory } from './camera';
 export { DoorbellAccessory } from './doorbell';
+export { MotionDeviceBase } from './motion-base';
+export type { MotionDevice } from './motion-base';
 export { NetworkAccessory } from './network';
 export { OwlAccessory } from './owl';

--- a/src/accessories/motion-base.ts
+++ b/src/accessories/motion-base.ts
@@ -1,0 +1,166 @@
+/**
+ * Abstract base class for motion-capable Blink devices.
+ *
+ * Provides shared functionality for camera, owl, and doorbell accessories:
+ * - Switch service for motion detection enable/disable
+ * - MotionSensor service for motion events
+ * - Camera controller for snapshot/streaming support
+ * - Polling state updates and motion trigger handling
+ *
+ * Subclasses supply device-specific API calls and metadata.
+ */
+
+import { CameraController, CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { BlinkCamerasPlatform } from '../platform';
+import { setTimeout, clearTimeout } from 'timers';
+import { BlinkCameraSource, createCameraControllerOptions, DeviceType } from './camera-source';
+
+export interface MotionDevice {
+  id: number;
+  network_id: number;
+  name: string;
+  enabled: boolean;
+  serial?: string;
+  thumbnail?: string;
+  type?: string;
+}
+
+export abstract class MotionDeviceBase<TDevice extends MotionDevice> {
+  protected readonly switchService: Service;
+  protected readonly motionService: Service;
+  protected readonly cameraController: CameraController;
+  protected motionDetected = false;
+  protected motionTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(
+    protected readonly platform: BlinkCamerasPlatform,
+    protected readonly accessory: PlatformAccessory,
+    protected device: TDevice,
+    private readonly modelName: string,
+    private readonly deviceLabel: string,
+    private readonly cameraSourceType: DeviceType,
+    motionSensorDisplayName?: string,
+  ) {
+    this.accessory.getService(this.platform.Service.AccessoryInformation)
+      ?.setCharacteristic(this.platform.Characteristic.Manufacturer, 'Blink')
+      .setCharacteristic(this.platform.Characteristic.Model, modelName)
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, device.serial ?? `${device.id}`);
+
+    this.switchService =
+      this.accessory.getService(this.platform.Service.Switch) ||
+      this.accessory.addService(this.platform.Service.Switch, `${device.name} Motion`, 'motion-switch');
+
+    this.switchService
+      .getCharacteristic(this.platform.Characteristic.On)
+      .onGet(() => this.device.enabled)
+      .onSet(async (value) => this.setMotionEnabled(value));
+
+    this.motionService =
+      this.accessory.getService(this.platform.Service.MotionSensor) ||
+      this.accessory.addService(
+        this.platform.Service.MotionSensor,
+        motionSensorDisplayName ?? device.name,
+        'motion-sensor',
+      );
+
+    this.motionService
+      .getCharacteristic(this.platform.Characteristic.MotionDetected)
+      .onGet(() => this.motionDetected);
+
+    this.motionService
+      .getCharacteristic(this.platform.Characteristic.StatusActive)
+      .onGet(() => this.device.enabled);
+
+    const cameraSource = new BlinkCameraSource(
+      this.platform.apiClient,
+      this.platform.api.hap,
+      device.network_id,
+      device.id,
+      cameraSourceType,
+      device.serial ?? `${device.id}`,
+      () => this.device.thumbnail,
+      (msg) => this.platform.log.debug(`[${device.name}] ${msg}`),
+      this.platform.streamingConfig,
+    );
+
+    this.cameraController = new this.platform.api.hap.CameraController(
+      createCameraControllerOptions(this.platform.api.hap, cameraSource, this.platform.streamingConfig),
+    );
+    this.accessory.configureController(this.cameraController);
+  }
+
+  protected abstract enableMotionApi(): Promise<void>;
+  protected abstract disableMotionApi(): Promise<void>;
+
+  private async setMotionEnabled(value: CharacteristicValue): Promise<void> {
+    const target = Boolean(value);
+
+    if (target === this.device.enabled) {
+      return;
+    }
+
+    try {
+      if (target) {
+        await this.enableMotionApi();
+        this.platform.log.info(`Enabled motion detection for ${this.deviceLabel}: ${this.device.name}`);
+      } else {
+        await this.disableMotionApi();
+        this.platform.log.info(`Disabled motion detection for ${this.deviceLabel}: ${this.device.name}`);
+      }
+
+      this.device.enabled = target;
+      this.accessory.context.device = this.device;
+
+      this.motionService
+        .getCharacteristic(this.platform.Characteristic.StatusActive)
+        .updateValue(target);
+    } catch (error) {
+      this.platform.log.error(
+        `Failed to ${target ? 'enable' : 'disable'} motion for ${this.deviceLabel} ${this.device.name}:`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  updateState(device: TDevice): void {
+    const previousEnabled = this.device.enabled;
+    this.device = device;
+    this.accessory.context.device = device;
+
+    if (previousEnabled !== device.enabled) {
+      this.switchService
+        .getCharacteristic(this.platform.Characteristic.On)
+        .updateValue(device.enabled);
+
+      this.motionService
+        .getCharacteristic(this.platform.Characteristic.StatusActive)
+        .updateValue(device.enabled);
+
+      this.platform.log.debug(
+        `${this.deviceLabel.charAt(0).toUpperCase() + this.deviceLabel.slice(1)} ${device.name} motion detection: ${device.enabled ? 'enabled' : 'disabled'}`,
+      );
+    }
+  }
+
+  triggerMotion(timeoutMs = 30000): void {
+    if (this.motionTimeout) {
+      clearTimeout(this.motionTimeout);
+    }
+
+    this.motionDetected = true;
+    this.motionService
+      .getCharacteristic(this.platform.Characteristic.MotionDetected)
+      .updateValue(true);
+
+    this.platform.log.info(`Motion detected on ${this.deviceLabel}: ${this.device.name}`);
+
+    this.motionTimeout = setTimeout(() => {
+      this.motionDetected = false;
+      this.motionService
+        .getCharacteristic(this.platform.Characteristic.MotionDetected)
+        .updateValue(false);
+      this.motionTimeout = null;
+    }, timeoutMs);
+  }
+}

--- a/src/accessories/motion-base.ts
+++ b/src/accessories/motion-base.ts
@@ -136,7 +136,7 @@ export abstract class MotionDeviceBase<TDevice extends MotionDevice> {
 
       this.motionService
         .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(target);
+        .updateValue(this.isMotionServiceActive());
     } catch (error) {
       this.platform.log.error(
         `Failed to ${target ? 'enable' : 'disable'} motion for ${this.deviceLabel} ${this.device.name}:`,

--- a/src/accessories/owl.ts
+++ b/src/accessories/owl.ts
@@ -12,165 +12,25 @@
  * Evidence: smali_classes9/com/immediasemi/blink/common/device/camera/wired/OwlApi.smali
  */
 
-import { CameraController, CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { PlatformAccessory } from 'homebridge';
 import { BlinkCamerasPlatform } from '../platform';
 import { BlinkOwl } from '../types';
-import { setTimeout, clearTimeout } from 'timers';
-import { BlinkCameraSource, createCameraControllerOptions } from './camera-source';
+import { MotionDeviceBase } from './motion-base';
 
-export class OwlAccessory {
-  private readonly switchService: Service;
-  private readonly motionService: Service;
-  private readonly cameraController: CameraController;
-  private motionDetected = false;
-  private motionTimeout: ReturnType<typeof setTimeout> | null = null;
-
+export class OwlAccessory extends MotionDeviceBase<BlinkOwl> {
   constructor(
-    private readonly platform: BlinkCamerasPlatform,
-    private readonly accessory: PlatformAccessory,
-    private device: BlinkOwl,
+    platform: BlinkCamerasPlatform,
+    accessory: PlatformAccessory,
+    device: BlinkOwl,
   ) {
-    // Configure accessory information
-    this.accessory.getService(this.platform.Service.AccessoryInformation)
-      ?.setCharacteristic(this.platform.Characteristic.Manufacturer, 'Blink')
-      .setCharacteristic(this.platform.Characteristic.Model, 'Mini')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, device.serial ?? `${device.id}`);
-
-    // Switch service for motion detection enable/disable
-    this.switchService =
-      this.accessory.getService(this.platform.Service.Switch) ||
-      this.accessory.addService(this.platform.Service.Switch, `${device.name} Motion`, 'motion-switch');
-
-    this.switchService
-      .getCharacteristic(this.platform.Characteristic.On)
-      .onGet(() => this.device.enabled)
-      .onSet(async (value) => this.setMotionEnabled(value));
-
-    // MotionSensor service for motion detection events
-    this.motionService =
-      this.accessory.getService(this.platform.Service.MotionSensor) ||
-      this.accessory.addService(this.platform.Service.MotionSensor, device.name, 'motion-sensor');
-
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.MotionDetected)
-      .onGet(() => this.motionDetected);
-
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.StatusActive)
-      .onGet(() => this.device.enabled);
-
-    // Camera controller for snapshot support
-    const cameraSource = new BlinkCameraSource(
-      this.platform.apiClient,
-      this.platform.api.hap,
-      device.network_id,
-      device.id,
-      'owl',
-      device.serial ?? `${device.id}`,
-      () => this.device.thumbnail,
-      (msg) => this.platform.log.debug(`[${device.name}] ${msg}`),
-      this.platform.streamingConfig,
-    );
-
-    this.cameraController = new this.platform.api.hap.CameraController(
-      createCameraControllerOptions(this.platform.api.hap, cameraSource, this.platform.streamingConfig),
-    );
-    this.accessory.configureController(this.cameraController);
+    super(platform, accessory, device, 'Mini', 'Mini', 'owl');
   }
 
-  /**
-   * Enable or disable motion detection
-   * Source: API Dossier Section 3.4 - enable/disable endpoints
-   */
-  private async setMotionEnabled(value: CharacteristicValue): Promise<void> {
-    const target = Boolean(value);
-
-    if (target === this.device.enabled) {
-      return;
-    }
-
-    try {
-      if (target) {
-        await this.platform.apiClient.enableOwlMotion(this.device.network_id, this.device.id);
-        this.platform.log.info(`Enabled motion detection for Mini: ${this.device.name}`);
-      } else {
-        await this.platform.apiClient.disableOwlMotion(this.device.network_id, this.device.id);
-        this.platform.log.info(`Disabled motion detection for Mini: ${this.device.name}`);
-      }
-
-      this.device.enabled = target;
-      this.accessory.context.device = this.device;
-
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(target);
-    } catch (error) {
-      this.platform.log.error(`Failed to ${target ? 'enable' : 'disable'} motion for Mini ${this.device.name}:`, error);
-      throw error;
-    }
+  protected async enableMotionApi(): Promise<void> {
+    await this.platform.apiClient.enableOwlMotion(this.device.network_id, this.device.id);
   }
 
-  /**
-   * Update device state from polling.
-   * Called by platform when homescreen data is refreshed.
-   * Updates Switch and StatusActive characteristics if enabled state changed.
-   *
-   * @param device - Fresh device data from Blink API homescreen response
-   */
-  updateState(device: BlinkOwl): void {
-    const previousEnabled = this.device.enabled;
-    this.device = device;
-    this.accessory.context.device = device;
-
-    if (previousEnabled !== device.enabled) {
-      this.switchService
-        .getCharacteristic(this.platform.Characteristic.On)
-        .updateValue(device.enabled);
-
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.StatusActive)
-        .updateValue(device.enabled);
-
-      this.platform.log.debug(
-        `Mini ${device.name} motion detection: ${device.enabled ? 'enabled' : 'disabled'}`,
-      );
-    }
-  }
-
-  /**
-   * Trigger motion detected event.
-   * Called when a new motion clip is detected for this Mini camera.
-   * Sets MotionDetected characteristic to true, then auto-resets after timeout.
-   *
-   * @param timeoutMs - Duration in milliseconds before resetting motion state (default 30000)
-   */
-  triggerMotion(timeoutMs = 30000): void {
-    if (this.motionTimeout) {
-      clearTimeout(this.motionTimeout);
-    }
-
-    this.motionDetected = true;
-    this.motionService
-      .getCharacteristic(this.platform.Characteristic.MotionDetected)
-      .updateValue(true);
-
-    this.platform.log.info(`Motion detected on Mini: ${this.device.name}`);
-
-    this.motionTimeout = setTimeout(() => {
-      this.motionDetected = false;
-      this.motionService
-        .getCharacteristic(this.platform.Characteristic.MotionDetected)
-        .updateValue(false);
-      this.motionTimeout = null;
-    }, timeoutMs);
-  }
-
-  /**
-   * Get the owl ID for matching with media clips.
-   *
-   * @returns The Blink owl (Mini camera) ID
-   */
-  getOwlId(): number {
-    return this.device.id;
+  protected async disableMotionApi(): Promise<void> {
+    await this.platform.apiClient.disableOwlMotion(this.device.network_id, this.device.id);
   }
 }

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -884,6 +884,13 @@ export class BlinkAuth {
    * @throws Blink2FARequiredError if 2FA verification is needed
    */
   async login(): Promise<void> {
+    if (!this.config.email || !this.config.password) {
+      throw new Error(
+        'No credentials available for OAuth login. '
+        + 'Authenticate via the plugin Custom UI or add username/password to config.',
+      );
+    }
+
     this.logDebug('Starting OAuth 2.0 Authorization Code Flow with PKCE...');
     this.logDebug(`  Email: ${redact(this.config.email, 3)}`);
     this.logDebug(`  Client ID: ${OAUTH_CLIENT_ID} (iOS)`);

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -40,10 +40,13 @@ import { generatePKCEPair, generateOAuthState } from './oauth-pkce';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { URL } from 'node:url';
+import { randomUUID } from 'node:crypto';
 
 type FetchResponse = Awaited<ReturnType<typeof fetch>>;
 
 const TOKEN_EXPIRY_BUFFER_MS = 60 * 60 * 1000; // 1 hour
+const REFRESH_MAX_RETRIES = 2;
+const REFRESH_RETRY_DELAYS_MS = [2000, 5000];
 
 const nullLogger: BlinkLogger = {
   debug: () => {},
@@ -208,6 +211,105 @@ export class BlinkAuth {
     if (this.debug) {
       this.log.info(`[Auth Debug] ${message}`, ...args);
     }
+  }
+
+  /**
+   * Redact sensitive form body fields for logging
+   */
+  private redactFormBody(body: string): string {
+    const params = new URLSearchParams(body);
+    const redacted = new URLSearchParams();
+    for (const [key, value] of params.entries()) {
+      const sensitiveKeys = ['password', 'refresh_token', 'code', 'code_verifier', 'csrf-token', '2fa_code'];
+      if (sensitiveKeys.includes(key)) {
+        redacted.set(key, redact(value, 3));
+      } else {
+        redacted.set(key, value);
+      }
+    }
+    return redacted.toString();
+  }
+
+  /**
+   * Redact authorization-related headers for logging
+   */
+  private redactHeaders(headers: Headers): Record<string, string> {
+    const result: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === 'authorization' || lowerKey === 'token-auth' || lowerKey === 'cookie') {
+        result[key] = value.length > 20 ? `${value.slice(0, 10)}...${value.slice(-4)}` : '***';
+      } else {
+        result[key] = value;
+      }
+    });
+    return result;
+  }
+
+  /**
+   * Centralized fetch wrapper for all OAuth requests.
+   * Provides: request ID tracking, detailed debug logging, network error handling.
+   */
+  private async authFetch(
+    stepLabel: string,
+    url: string,
+    init: RequestInit,
+  ): Promise<FetchResponse> {
+    const requestId = randomUUID().slice(0, 8);
+    const method = init.method ?? 'GET';
+
+    this.logDebug(`[${requestId}] ── ${stepLabel} ──`);
+    this.logDebug(`[${requestId}] ${method} ${url}`);
+    this.logDebug(`[${requestId}] Request headers: ${JSON.stringify(this.redactHeaders(init.headers as Headers))}`);
+    if (init.body) {
+      this.logDebug(`[${requestId}] Request body: ${this.redactFormBody(init.body as string)}`);
+    }
+    if (init.redirect) {
+      this.logDebug(`[${requestId}] Redirect policy: ${init.redirect}`);
+    }
+
+    const startTime = Date.now();
+    let response: FetchResponse;
+    try {
+      response = await fetch(url, init);
+    } catch (error) {
+      const elapsed = Date.now() - startTime;
+      const err = error as Error;
+      const causeMsg = err.cause ? ` | cause: ${(err.cause as Error).message ?? String(err.cause)}` : '';
+      this.log.error(
+        `[Auth] [${requestId}] Network error during "${stepLabel}" after ${elapsed}ms: ` +
+        `${method} ${url} → ${err.name}: ${err.message}${causeMsg}`,
+      );
+      this.logDebug(`[${requestId}] Full error: ${JSON.stringify({ name: err.name, message: err.message, cause: err.cause, stack: err.stack })}`);
+      throw new BlinkAuthenticationError(
+        `Network error during ${stepLabel}: ${err.message}`,
+        {
+          status: 0,
+          statusText: 'Network Error',
+          message: `${err.name}: ${err.message}${causeMsg}`,
+          headers: {},
+        },
+      );
+    }
+
+    const elapsed = Date.now() - startTime;
+    this.logDebug(`[${requestId}] Response: ${response.status} ${response.statusText} (${elapsed}ms)`);
+
+    // Log response headers
+    const respHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === 'token-auth' || lowerKey === 'authorization') {
+        respHeaders[key] = value.length > 20 ? `${value.slice(0, 10)}...${value.slice(-4)}` : '***';
+      } else if (lowerKey === 'set-cookie') {
+        respHeaders[key] = `<${value.length} chars>`;
+      } else {
+        respHeaders[key] = value;
+      }
+    });
+    this.logDebug(`[${requestId}] Response headers: ${JSON.stringify(respHeaders)}`);
+
+    return response;
   }
 
   private async ensureStateLoaded(): Promise<void> {
@@ -417,8 +519,6 @@ export class BlinkAuth {
     authorizeUrl.searchParams.set('device_os_version', '26.1');
     authorizeUrl.searchParams.set('hardware_id', this.config.hardwareId);
 
-    this.logDebug(`OAuth authorize request: ${authorizeUrl.toString()}`);
-
     const headers = new Headers({
       ...buildOAuthHeaders(),
     });
@@ -427,14 +527,13 @@ export class BlinkAuth {
       headers.set('Cookie', this.sessionCookies);
     }
 
-    const response = await fetch(authorizeUrl.toString(), {
+    const response = await this.authFetch('Step 1: OAuth Authorize (PKCE)', authorizeUrl.toString(), {
       method: 'GET',
       headers,
-      redirect: 'manual', // Don't follow redirects automatically
+      redirect: 'manual',
     });
 
     this.extractAndMergeCookies(response);
-    this.logDebug(`Authorize response: ${response.status}`);
   }
 
   /**
@@ -443,7 +542,6 @@ export class BlinkAuth {
    */
   private async oauthGetSigninPage(): Promise<string> {
     const signinUrl = getOAuthSigninUrl(this.config);
-    this.logDebug(`Fetching signin page: ${signinUrl}`);
 
     const headers = new Headers({
       ...buildOAuthHeaders(),
@@ -453,7 +551,7 @@ export class BlinkAuth {
       headers.set('Cookie', this.sessionCookies);
     }
 
-    const response = await fetch(signinUrl, {
+    const response = await this.authFetch('Step 2: Get Signin Page', signinUrl, {
       method: 'GET',
       headers,
     });
@@ -494,7 +592,6 @@ export class BlinkAuth {
    */
   private async oauthSignin(csrfToken: string): Promise<boolean> {
     const signinUrl = getOAuthSigninUrl(this.config);
-    this.logDebug(`Submitting credentials to: ${signinUrl}`);
 
     // Use same field names as blinkpy: username, password, csrf-token
     const formData = new URLSearchParams({
@@ -514,7 +611,7 @@ export class BlinkAuth {
       headers.set('Cookie', this.sessionCookies);
     }
 
-    const response = await fetch(signinUrl, {
+    const response = await this.authFetch('Step 3: Submit Credentials', signinUrl, {
       method: 'POST',
       headers,
       body: formData.toString(),
@@ -522,7 +619,6 @@ export class BlinkAuth {
     });
 
     this.extractAndMergeCookies(response);
-    this.logDebug(`Signin response: ${response.status}`);
 
     // Status 412 = 2FA required (returns JSON with phone, user_id, etc.)
     if (response.status === 412) {
@@ -619,7 +715,6 @@ export class BlinkAuth {
     }
 
     const verifyUrl = getOAuth2FAVerifyUrl(this.config);
-    this.logDebug(`Verifying 2FA at: ${verifyUrl}`);
 
     // Field names match blinkpy: 2fa_code, csrf-token, remember_me
     const formData = new URLSearchParams({
@@ -639,7 +734,7 @@ export class BlinkAuth {
       headers.set('Cookie', this.sessionCookies);
     }
 
-    const response = await fetch(verifyUrl, {
+    const response = await this.authFetch('Step 4: Verify 2FA', verifyUrl, {
       method: 'POST',
       headers,
       body: formData.toString(),
@@ -647,7 +742,6 @@ export class BlinkAuth {
     });
 
     this.extractAndMergeCookies(response);
-    this.logDebug(`2FA verify response: ${response.status}`);
 
     // Status 201 means auth-completed (success)
     if (response.status === 201) {
@@ -692,8 +786,6 @@ export class BlinkAuth {
     // Use bare authorize URL - session remembers the original OAuth request
     const authorizeUrl = getOAuthAuthorizeUrl(this.config);
 
-    this.logDebug(`Getting authorization code (bare URL): ${authorizeUrl}`);
-
     const headers = new Headers({
       ...buildOAuthHeaders(),
     });
@@ -702,7 +794,7 @@ export class BlinkAuth {
       headers.set('Cookie', this.sessionCookies);
     }
 
-    const response = await fetch(authorizeUrl, {
+    const response = await this.authFetch('Step 5: Get Authorization Code', authorizeUrl, {
       method: 'GET',
       headers,
       redirect: 'manual',
@@ -743,7 +835,6 @@ export class BlinkAuth {
     }
 
     const tokenUrl = getOAuthTokenUrl(this.config);
-    this.logDebug(`Exchanging code for tokens: ${tokenUrl}`);
 
     const formData = new URLSearchParams({
       grant_type: 'authorization_code',
@@ -766,7 +857,7 @@ export class BlinkAuth {
       headers.set('Cookie', this.sessionCookies);
     }
 
-    const response = await fetch(tokenUrl, {
+    const response = await this.authFetch('Step 6: Exchange Code for Tokens', tokenUrl, {
       method: 'POST',
       headers,
       body: formData.toString(),
@@ -814,15 +905,20 @@ export class BlinkAuth {
     // TypeScript control-flow doesn't track this, so we use a non-null assertion
     const currentSession = this.oauthSession!;
     if (!signinSuccess && currentSession.requires2FA) {
-      this.logDebug('2FA verification required');
+      this.logDebug('login → signin returned false → 2FA required');
       
-      // If a 2FA code was provided in config, try it automatically
-      if (this.config.twoFactorCode) {
-        this.logDebug('Using 2FA code from config');
+      // If a 2FA code was provided in config (and not locked), try it automatically
+      if (this.config.twoFactorCode && !this.config.authLocked) {
+        this.logDebug('login → auto-submitting 2FA code from config');
         await this.complete2FA(this.config.twoFactorCode);
         return;
       }
 
+      if (this.config.authLocked) {
+        this.logDebug('login → authLocked=true, not auto-submitting 2FA code');
+      }
+
+      this.logDebug('login → no usable 2FA code → throwing Blink2FARequiredError');
       throw new Blink2FARequiredError(
         '2FA verification required. Call complete2FA(pin) with the PIN sent to your device.',
         {
@@ -832,13 +928,15 @@ export class BlinkAuth {
       );
     }
 
+    this.logDebug('login → signin succeeded → getting authorization code');
+
     // Step 5: Get authorization code (if not already captured)
     const authorizationCode = await this.oauthGetAuthorizationCode();
 
     // Step 6: Exchange code for tokens
     await this.oauthExchangeCode(authorizationCode);
 
-    this.logDebug('OAuth 2.0 login completed successfully');
+    this.logDebug('login → OAuth 2.0 login completed successfully');
   }
 
   /**
@@ -874,7 +972,8 @@ export class BlinkAuth {
   }
 
   /**
-   * Refresh tokens using refresh_token grant
+   * Refresh tokens using refresh_token grant.
+   * Retries transient network errors up to REFRESH_MAX_RETRIES times.
    */
   async refreshTokens(): Promise<void> {
     await this.ensureStateLoaded();
@@ -884,9 +983,7 @@ export class BlinkAuth {
     }
 
     const tokenUrl = getOAuthTokenUrl(this.config);
-    this.logDebug('Starting token refresh...');
-    this.logDebug(`  URL: ${tokenUrl}`);
-    this.logDebug(`  Refresh token: ${redact(this.refreshToken)}`);
+    this.logDebug(`Refresh token: ${redact(this.refreshToken)}`);
 
     const formData = new URLSearchParams({
       grant_type: 'refresh_token',
@@ -900,23 +997,39 @@ export class BlinkAuth {
       Accept: 'application/json',
     });
 
-    const response = await fetch(tokenUrl, {
-      method: 'POST',
-      headers,
-      body: formData.toString(),
-    });
+    let lastError: Error | null = null;
+    for (let attempt = 0; attempt <= REFRESH_MAX_RETRIES; attempt++) {
+      if (attempt > 0) {
+        const delay = REFRESH_RETRY_DELAYS_MS[attempt - 1] ?? 5000;
+        this.logDebug(`Token refresh retry ${attempt}/${REFRESH_MAX_RETRIES} after ${delay}ms delay...`);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
 
-    this.logDebug(`Response: ${response.status} ${response.statusText}`);
+      try {
+        const response = await this.authFetch(
+          attempt === 0 ? 'Token Refresh' : `Token Refresh (retry ${attempt})`,
+          tokenUrl,
+          { method: 'POST', headers, body: formData.toString() },
+        );
 
-    if (!response.ok) {
-      await this.handleAuthError('refresh', response);
+        if (!response.ok) {
+          await this.handleAuthError('refresh', response);
+        }
+
+        const body = (await response.json()) as BlinkOAuthV2TokenResponse;
+        this.logDebug('Token refresh successful');
+        this.logDebug(`  Token expires in: ${body.expires_in} seconds`);
+        this.captureTokens(body, response.headers.get('TOKEN-AUTH'));
+        return;
+      } catch (error) {
+        lastError = error as Error;
+        const isTransient = lastError instanceof BlinkAuthenticationError && lastError.details.status === 0;
+        if (!isTransient || attempt === REFRESH_MAX_RETRIES) {
+          throw lastError;
+        }
+        this.log.warn(`[Auth] Token refresh attempt ${attempt + 1} failed (transient): ${lastError.message}`);
+      }
     }
-
-    const body = (await response.json()) as BlinkOAuthV2TokenResponse;
-    this.logDebug('Token refresh successful');
-    this.logDebug(`  Token expires in: ${body.expires_in} seconds`);
-
-    this.captureTokens(body, response.headers.get('TOKEN-AUTH'));
   }
 
   private async handleAuthError(operation: string, response: FetchResponse): Promise<never> {
@@ -982,19 +1095,30 @@ export class BlinkAuth {
   async ensureValidToken(): Promise<void> {
     await this.ensureStateLoaded();
     if (!this.accessToken) {
-      this.logDebug('No access token, initiating login...');
+      this.logDebug('ensureValidToken → no access token → initiating login');
       await this.login();
       return;
     }
 
     if (this.isTokenExpired()) {
-      this.logDebug('Access token expired, refreshing...');
-      await this.refreshTokens();
+      this.logDebug('ensureValidToken → access token expired → refreshing');
+      try {
+        await this.refreshTokens();
+      } catch (error) {
+        this.log.warn(`[Auth] Token refresh failed, falling back to full login: ${(error as Error).message}`);
+        this.logDebug('ensureValidToken → refresh failed → falling back to login()');
+        await this.login();
+      }
     } else if (this.isTokenExpiringSoon()) {
-      this.logDebug('Access token expiring soon, refreshing proactively...');
-      await this.refreshTokens();
+      this.logDebug(`ensureValidToken → token expiring soon (expires ${this.tokenExpiry?.toISOString()}) → proactive refresh`);
+      try {
+        await this.refreshTokens();
+      } catch (error) {
+        this.log.warn(`[Auth] Proactive token refresh failed (non-critical): ${(error as Error).message}`);
+        this.logDebug('ensureValidToken → proactive refresh failed → continuing with current token');
+      }
     } else {
-      this.logDebug(`Access token valid until ${this.tokenExpiry?.toISOString()}`);
+      this.logDebug(`ensureValidToken → token valid until ${this.tokenExpiry?.toISOString()}`);
     }
   }
 

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -21,6 +21,7 @@ import {
   BlinkLogger,
   BlinkOAuthSessionState,
   BlinkOAuthV2TokenResponse,
+  nullLogger,
 } from '../types';
 import {
   buildOAuthHeaders,
@@ -47,13 +48,6 @@ type FetchResponse = Awaited<ReturnType<typeof fetch>>;
 const TOKEN_EXPIRY_BUFFER_MS = 60 * 60 * 1000; // 1 hour
 const REFRESH_MAX_RETRIES = 2;
 const REFRESH_RETRY_DELAYS_MS = [2000, 5000];
-
-const nullLogger: BlinkLogger = {
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-};
 
 class FileAuthStorage implements BlinkAuthStorage {
   constructor(private readonly filePath: string) {}
@@ -417,7 +411,7 @@ export class BlinkAuth {
 
   /**
    * Extract CSRF token from HTML response
-   * Looks for: 
+   * Looks for:
    * - JSON in <script id="oauth-args">{"csrf-token":"..."}</script>
    * - <input type="hidden" name="_token" value="...">
    * - <meta name="csrf-token" content="...">
@@ -581,11 +575,11 @@ export class BlinkAuth {
   /**
    * Step 3: Submit credentials
    * POST /oauth/v2/signin
-   * 
+   *
    * Returns:
    * - true: Login successful, authorization code available
    * - false: 2FA required, need to call oauthVerify2FA
-   * 
+   *
    * Status codes:
    * - 302: Success (redirect to authorize)
    * - 412: 2FA required (JSON body with phone, user_id, etc.)
@@ -699,12 +693,12 @@ export class BlinkAuth {
   /**
    * Step 4: Submit 2FA PIN
    * POST /oauth/v2/2fa/verify
-   * 
+   *
    * Field names verified against working flow:
    * - 2fa_code: The verification code
    * - csrf-token: The CSRF token from signin page
    * - remember_me: Whether to remember device
-   * 
+   *
    * Response:
    * - 201: Success, body contains {"status":"auth-completed"}
    * - 302: Success, redirect to authorize
@@ -768,7 +762,7 @@ export class BlinkAuth {
 
   /**
    * Step 5: Get authorization code from redirect
-   * 
+   *
    * CRITICAL: After 2FA, use bare /oauth/v2/authorize URL WITHOUT params.
    * The server session remembers the original OAuth request parameters.
    * Sending params again causes redirect back to signin.
@@ -818,7 +812,7 @@ export class BlinkAuth {
   /**
    * Step 6: Exchange authorization code for tokens
    * POST /oauth/token with grant_type=authorization_code
-   * 
+   *
    * Parameters validated against working flow:
    * - grant_type: authorization_code
    * - code: the authorization code
@@ -913,7 +907,7 @@ export class BlinkAuth {
     const currentSession = this.oauthSession!;
     if (!signinSuccess && currentSession.requires2FA) {
       this.logDebug('login → signin returned false → 2FA required');
-      
+
       // If a 2FA code was provided in config (and not locked), try it automatically
       if (this.config.twoFactorCode && !this.config.authLocked) {
         this.logDebug('login → auto-submitting 2FA code from config');

--- a/src/blink-api/client.ts
+++ b/src/blink-api/client.ts
@@ -637,12 +637,11 @@ export class BlinkApi {
   }
 
   /**
-   * Update/extend an ongoing command (e.g., live view)
+    * Update an onboarding/status command
    * Source: API Dossier Section 3.10 - POST /accounts/{account_id}/networks/{network}/commands/{command}/update
    * Note: No version prefix - uses root URL (without /api/)
-   *
-   * Returns null if the command no longer exists (404) - this happens when the stream
-   * has already ended but the keep-alive timer hasn't been cleared yet.
+    *
+    * Returns null if the command no longer exists (404).
    */
   async updateCommand(networkId: number, commandId: number): Promise<BlinkCommandStatus | null> {
     const accountId = await this.ensureAccountId();

--- a/src/blink-api/http.ts
+++ b/src/blink-api/http.ts
@@ -9,7 +9,7 @@
 import { BlinkAuth } from './auth';
 import { buildDefaultHeaders } from './headers';
 import { getRestBaseUrl } from './urls';
-import { BlinkConfig, BlinkLogger, HttpMethod } from '../types';
+import { BlinkConfig, BlinkLogger, HttpMethod, nullLogger } from '../types';
 import { randomUUID } from 'node:crypto';
 
 /**
@@ -21,16 +21,6 @@ import { randomUUID } from 'node:crypto';
  */
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Null logger that discards all output
- */
-const nullLogger: BlinkLogger = {
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-};
 
 /**
  * Redact authorization headers for logging

--- a/src/homebridge-ui/public/index.html
+++ b/src/homebridge-ui/public/index.html
@@ -566,6 +566,7 @@
       const status = await homebridge.request('/status');
       const authenticated = !!status?.authenticated;
       updateAccountDisplay(authenticated, status);
+      setAuthLockVisibility(authenticated);
       if (authenticated) {
         savedUsername = resolveUsername(status);
         savedTier = resolveTier(status);
@@ -735,6 +736,7 @@
   // Handle successful authentication
   async function handleAuthSuccess(data) {
     hideStatusError();
+    setAuthLockVisibility(true);
     // Update config with credentials
     let config = pluginConfig[0] || { platform: 'BlinkCameras', name: 'Blink' };
 
@@ -806,10 +808,19 @@
   });
 
   // Auth Lock Controls
+  const authLockSection = document.getElementById('authLockSection');
   const lockControls = document.getElementById('lockControls');
   const unlockControls = document.getElementById('unlockControls');
   const lockAuthBtn = document.getElementById('lockAuthBtn');
   const unlockAuthBtn = document.getElementById('unlockAuthBtn');
+
+  function setAuthLockVisibility(authenticated) {
+    if (authenticated) {
+      authLockSection.classList.remove('hidden');
+    } else {
+      authLockSection.classList.add('hidden');
+    }
+  }
 
   function updateLockUI(locked) {
     if (locked) {

--- a/src/homebridge-ui/public/index.html
+++ b/src/homebridge-ui/public/index.html
@@ -328,6 +328,31 @@
             Configure Camera Settings
           </button>
         </div>
+
+        <hr class="mt-4 mb-3">
+
+        <!-- Auth Lock Controls -->
+        <div id="authLockSection">
+          <h6 class="text-muted">Authentication Lock</h6>
+          <p class="small text-muted mb-2">
+            Lock authentication to prevent stale 2FA/verification codes from interfering with token refresh.
+            Locking clears stored codes from your config.
+          </p>
+
+          <div id="lockControls">
+            <button type="button" class="btn btn-sm btn-outline-warning" id="lockAuthBtn">
+              🔒 Lock Authentication
+            </button>
+          </div>
+
+          <div id="unlockControls" class="hidden">
+            <span class="badge badge-warning mb-2">🔒 Authentication Locked</span>
+            <br>
+            <button type="button" class="btn btn-sm btn-outline-danger" id="unlockAuthBtn">
+              🔓 Unlock &amp; Re-authenticate
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -779,6 +804,65 @@
       console.error('[Blink UI] Config save failed:', error);
     }
   });
+
+  // Auth Lock Controls
+  const lockControls = document.getElementById('lockControls');
+  const unlockControls = document.getElementById('unlockControls');
+  const lockAuthBtn = document.getElementById('lockAuthBtn');
+  const unlockAuthBtn = document.getElementById('unlockAuthBtn');
+
+  function updateLockUI(locked) {
+    if (locked) {
+      lockControls.classList.add('hidden');
+      unlockControls.classList.remove('hidden');
+    } else {
+      lockControls.classList.remove('hidden');
+      unlockControls.classList.add('hidden');
+    }
+  }
+
+  lockAuthBtn.addEventListener('click', async () => {
+    try {
+      await homebridge.request('/lock');
+
+      // Update local config
+      let config = pluginConfig[0] || {};
+      config.authLocked = true;
+      delete config.twoFactorCode;
+      delete config.clientVerificationCode;
+      delete config.accountVerificationCode;
+      pluginConfig[0] = config;
+      await homebridge.updatePluginConfig(pluginConfig);
+
+      updateLockUI(true);
+      homebridge.toast.success('Authentication locked. Stored verification codes cleared.', 'Locked');
+    } catch (e) {
+      showError(e.message || 'Failed to lock authentication');
+    }
+  });
+
+  unlockAuthBtn.addEventListener('click', async () => {
+    try {
+      await homebridge.request('/unlock');
+
+      // Update local config
+      let config = pluginConfig[0] || {};
+      config.authLocked = false;
+      pluginConfig[0] = config;
+      await homebridge.updatePluginConfig(pluginConfig);
+
+      updateLockUI(false);
+      showStep('login');
+      homebridge.toast.info('Authentication unlocked. You can re-authenticate now.', 'Unlocked');
+    } catch (e) {
+      showError(e.message || 'Failed to unlock authentication');
+    }
+  });
+
+  // Initialize lock UI from config
+  if (pluginConfig[0]?.authLocked) {
+    updateLockUI(true);
+  }
 
   // Check for existing auth on load
   // If already configured (has username), show schema form immediately

--- a/src/homebridge-ui/public/index.html
+++ b/src/homebridge-ui/public/index.html
@@ -864,23 +864,15 @@
     updateLockUI(true);
   }
 
-  // Check for existing auth on load
-  // If already configured (has username), show schema form immediately
-  // The login wizard is only needed for initial setup or re-authentication
-  if (pluginConfig.length > 0 && pluginConfig[0].username) {
-    // Already configured - show schema form by default
-    homebridge.showSchemaForm();
-    
-    // Also check auth status to show appropriate UI state
-    await refreshAuthStatus();
+  // Check auth status on load and drive UI from token state, not config fields.
+  const status = await refreshAuthStatus();
+  if (status?.authenticated) {
+    savedUsername = resolveUsername(status) || 'Unknown';
+    savedTier = resolveTier(status) || document.getElementById('tier').value;
+    handleAuthSuccess(status);
   } else {
-    // No config yet - user needs to authenticate first
-    const status = await refreshAuthStatus();
-    if (status?.authenticated) {
-      savedUsername = resolveUsername(status) || 'Unknown';
-      savedTier = resolveTier(status) || document.getElementById('tier').value;
-      handleAuthSuccess(status);
-    }
+    homebridge.hideSchemaForm();
+    showStep('login');
   }
 })();
 </script>

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -158,7 +158,8 @@ class BlinkUiServer extends HomebridgePluginUiServer {
   private getAuthStoragePath(): string {
     // Use a sibling directory to Homebridge storage for auth persistence
     const storagePath = this.homebridgeStoragePath ?? '.';
-    return path.join(storagePath, 'blink-auth', 'auth-state.json');
+    const persistBase = path.dirname(storagePath);
+    return path.join(persistBase, 'blink-auth', 'auth-state.json');
   }
 
   /**

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -158,7 +158,7 @@ class BlinkUiServer extends HomebridgePluginUiServer {
   private getAuthStoragePath(): string {
     // Use a sibling directory to Homebridge storage for auth persistence
     const storagePath = this.homebridgeStoragePath ?? '.';
-    return path.join(storagePath, '..', 'blink-auth', 'auth-state.json');
+    return path.join(storagePath, 'blink-auth', 'auth-state.json');
   }
 
   /**

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -43,6 +43,16 @@ interface AuthStatus {
   message?: string;
 }
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const VERIFY_CODE_PATTERN = /^[A-Za-z0-9-]{4,12}$/;
+
+function redactSecrets(message: string): string {
+  return message
+    .replace(/(password|pass|pwd)\s*[=:]\s*[^\s,;]+/gi, '$1=<redacted>')
+    .replace(/(token-auth|access_token|refresh_token|authorization)\s*[=:]\s*[^\s,;]+/gi, '$1=<redacted>')
+    .replace(/(two[_-]?factor|verification|otp|code)\s*[=:]\s*[^\s,;]+/gi, '$1=<redacted>');
+}
+
 // Logger that sends messages to the UI
 class UiLogger implements BlinkLogger {
   private server: BlinkUiServer;
@@ -101,7 +111,11 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    * Push log messages to the UI for display
    */
   pushLog(level: string, message: string): void {
-    this.pushEvent('log', { level, message, timestamp: new Date().toISOString() });
+    this.pushEvent('log', {
+      level,
+      message: redactSecrets(message),
+      timestamp: new Date().toISOString(),
+    });
   }
 
   private resolveDebugEnabled(): boolean {
@@ -175,10 +189,17 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    * Handle login request - initiates OAuth flow
    */
   async handleLogin(payload: LoginRequest): Promise<AuthStatus> {
-    const { username, password, deviceId, tier } = payload;
+    const username = payload.username?.trim();
+    const password = payload.password?.trim();
+    const deviceId = payload.deviceId?.trim();
+    const tier = payload.tier?.trim();
 
     if (!username || !password) {
       throw new RequestError('Username and password are required', { status: 400 });
+    }
+
+    if (!EMAIL_PATTERN.test(username)) {
+      throw new RequestError('A valid email address is required', { status: 400 });
     }
 
     // Build config for Blink API
@@ -188,7 +209,7 @@ class BlinkUiServer extends HomebridgePluginUiServer {
       hardwareId: deviceId || this.generateDeviceId(),
       tier: tier || 'prod',
       authStoragePath: this.getAuthStoragePath(),
-      debugAuth: true,
+      debugAuth: false,
       logger: new UiLogger(this),
     };
 
@@ -284,10 +305,16 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    * Handle verification code submission
    */
   async handleVerify(payload: VerifyRequest): Promise<AuthStatus> {
-    const { code, type, trustDevice } = payload;
+    const code = payload.code?.trim();
+    const type = payload.type;
+    const trustDevice = payload.trustDevice;
 
     if (!code) {
       throw new RequestError('Verification code is required', { status: 400 });
+    }
+
+    if (!VERIFY_CODE_PATTERN.test(code)) {
+      throw new RequestError('Verification code must be 4-12 alphanumeric characters', { status: 400 });
     }
 
     if (!this.blinkApi || !this.pendingConfig) {

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -88,6 +88,8 @@ class BlinkUiServer extends HomebridgePluginUiServer {
     this.registerRequest('/verify', this.handleVerify.bind(this));
     this.registerRequest('/status', this.handleStatus.bind(this));
     this.registerRequest('/logout', this.handleLogout.bind(this));
+    this.registerRequest('/lock', this.handleLock.bind(this));
+    this.registerRequest('/unlock', this.handleUnlock.bind(this));
     this.registerRequest('/test-connection', this.handleTestConnection.bind(this));
 
     // Signal ready
@@ -373,6 +375,25 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    * Clear authentication state
    */
   async handleLogout(): Promise<{ success: boolean }> {
+    this.blinkApi = null;
+    this.pendingConfig = null;
+    this.authStatus = { authenticated: false };
+    return { success: true };
+  }
+
+  /**
+   * Lock authentication — clears stored verification codes
+   */
+  async handleLock(): Promise<{ success: boolean }> {
+    this.logDebug('Locking authentication state');
+    return { success: true };
+  }
+
+  /**
+   * Unlock authentication — allows re-authentication
+   */
+  async handleUnlock(): Promise<{ success: boolean }> {
+    this.logDebug('Unlocking authentication state');
     this.blinkApi = null;
     this.pendingConfig = null;
     this.authStatus = { authenticated: false };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -72,6 +72,7 @@ interface BlinkPlatformConfig extends PlatformConfig {
   audioBitrate?: number;
   videoBitrate?: number;
   debugAuth?: boolean;
+  authLocked?: boolean;
   debugStreamPath?: string;
   /** Snapshot cache TTL in seconds. Set to 0 to always request fresh snapshots. Default: 60 */
   snapshotCacheTTL?: number;
@@ -159,6 +160,7 @@ export class BlinkCamerasPlatform implements DynamicPlatformPlugin {
       tier: this.config.tier,
       sharedTier: this.config.sharedTier,
       debugAuth: this.config.debugAuth,
+      authLocked: this.config.authLocked,
       logger: this.log,
     });
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -265,7 +265,7 @@ export class BlinkCamerasPlatform implements DynamicPlatformPlugin {
     return device.name;
   }
 
-  public getDeviceMotionTimeout(device: { id: number; serial?: string }): number {
+  public getDeviceMotionTimeout(device: { id: number; name?: string; serial?: string }): number {
     // New array-based overrides (preferred)
     const overrides = this.config.deviceSettingOverrides;
     if (overrides && Array.isArray(overrides)) {
@@ -274,6 +274,7 @@ export class BlinkCamerasPlatform implements DynamicPlatformPlugin {
           continue;
         }
         if (
+          (device.name && override.deviceIdentifier === device.name) ||
           override.deviceIdentifier === `${device.id}` ||
           (device.serial && override.deviceIdentifier === device.serial)
         ) {

--- a/src/types/blink-api.ts
+++ b/src/types/blink-api.ts
@@ -372,6 +372,13 @@ export interface BlinkLogger {
   error(message: string, ...parameters: unknown[]): void;
 }
 
+export const nullLogger: BlinkLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
 /**
  * Plugin configuration
  * Source: API Dossier Section 2.1 (OAuth parameters) and Section 1.1 (Base URLs)

--- a/src/types/blink-api.ts
+++ b/src/types/blink-api.ts
@@ -392,6 +392,8 @@ export interface BlinkConfig {
   sharedTier?: string;
   /** Enable verbose auth diagnostics */
   debugAuth?: boolean;
+  /** Lock auth state — ignore stored 2FA/verification codes, use only token refresh */
+  authLocked?: boolean;
   /** Logger for diagnostic output */
   logger?: BlinkLogger;
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the authentication flow and configuration schema for the Homebridge Blink Cameras plugin. The main goal is to remove all legacy credential and verification code fields from the schema and documentation, ensuring authentication is handled exclusively through the custom UI. This reduces the risk of credential leakage, simplifies configuration, and hardens security. Additionally, the schema is refactored to use array-based device customization, and new regression tests are added to prevent reintroduction of deprecated auth fields.

**Authentication Flow & Security:**

* Removed all authentication credential and verification code fields (`username`, `password`, `twoFactorCode`, `clientVerificationCode`, `accountVerificationCode`) from `config.schema.json`, and updated documentation to reflect that authentication is now handled solely via the custom UI. [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L19-L31) [[2]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L45-L106) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-R75) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-L85) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-L112) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R138-R170)
* Added a regression test (`__tests__/schema-auth-ui.test.ts`) to ensure schema and layout never reintroduce forbidden credential/code fields and that only the custom UI is used for authentication.
* Updated token persistence to use a single auth state file, ensuring UI-based login persists across restarts without requiring credentials in `config.json`. (CHANGELOG.md [CHANGELOG.mdR1-R15](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R15))

**Schema Refactoring & Device Customization:**

* Migrated device name and settings overrides from object-based to array-based patterns (`deviceNameOverrides`, `deviceSettingOverrides`), improving schema clarity and validation.
* Removed deprecated or redundant fields (`sharedTier`, object-based device overrides), and ensured the schema layout does not duplicate fields or expose internal options. [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L45-L106) [[2]](diffhunk://#diff-c84cf413caed401cd7ffd63553fe4eeaab67856fcdf6eb097bc7fb57412ec193R1-R169)

**Usability & Documentation:**

* Updated `README.md` to clarify that credentials should not be placed in `config.json` and that all authentication is performed through the custom UI. Added a manual checklist and re-authentication instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R74-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-L85) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-L112) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R138-R170)
* Added new configuration options: `authLocked` (to lock authentication state post-login) and improved help text for several fields. [[1]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R65-R78) [[2]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5R104-R112) [[3]](diffhunk://#diff-be1695b1e63a508d59982601f9e1fb7f58247deecb1e427adb77bcad758ae5e5L169-L182)

**Testing & Changelog:**

* Added comprehensive regression and integrity tests for schema layout, forbidden fields, and device customization patterns.
* Added a new `CHANGELOG.md` file documenting these changes and fixes.

These changes collectively modernize the authentication flow, improve security, and simplify configuration for users and maintainers.