### PR TITLE
[codex] harden auth and live stream security

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ unless Blink support has confirmed your camera only exposes an insecure/self-sig
 argument, and FFmpeg stderr logs. The generated HomeKit `srtp://` output address may still appear in
 FFmpeg argument diagnostics. Debug recordings are written under
 `<debugStreamPath>/blink-stream-recordings/`, use hashed camera identifiers in filenames, and are
-created with owner-only file permissions where the filesystem supports POSIX modes.
+created with owner-only file permissions where the filesystem supports POSIX modes. Existing
+recordings from older versions under `<debugStreamPath>/blink-stream-*.ts` are not moved or
+re-permissioned automatically; delete them or migrate them into a private directory if they contain
+sensitive footage.
 
 If you use [`brew`](http://brew.sh) (MacOS or Linux), install `ffmpeg` using:
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Add a platform entry to your Homebridge `config.json`:
 | `videoBitrate` | No | - | Cap video bitrate (kbps) |
 | `videoEncoder` | No | `auto` | Preferred FFmpeg video encoder; `auto` prefers platform hardware encoding and falls back to `libx264` |
 | `verifyImmisTls` | No | `true` | Verify TLS certificates and hostnames for Blink IMMIS live streams |
-| `debugStreamPath` | No | - | Save raw MPEG-TS stream recordings for debugging |
+| `debugStreamPath` | No | - | Save raw MPEG-TS stream recordings under a `blink-stream-recordings` child directory for debugging |
 | `snapshotCacheTTL` | No | `60` | Snapshot cache duration (seconds); `0` always fetches a new snapshot |
 | `persistSnapshotCache` | No | `false` | Keep the last snapshot indefinitely and expose a per-camera `Refresh Snapshot` switch in Home |
 | `excludeDevices` | No | - | List of device IDs/serials/names to exclude |
@@ -192,8 +192,11 @@ to `libx264` if the hardware encoder cannot be started.
 
 IMMIS live streams verify the upstream TLS certificate and hostname by default. Keep `verifyImmisTls: true`
 unless Blink support has confirmed your camera only exposes an insecure/self-signed stream endpoint. When
-`ffmpegDebug` is enabled, stream URLs and SRTP keys are redacted from logs. Debug recordings use hashed
-camera identifiers in filenames and are created with owner-only file permissions.
+`ffmpegDebug` is enabled, Blink live-view input URLs and SRTP keys are redacted from startup, FFmpeg
+argument, and FFmpeg stderr logs. The generated HomeKit `srtp://` output address may still appear in
+FFmpeg argument diagnostics. Debug recordings are written under
+`<debugStreamPath>/blink-stream-recordings/`, use hashed camera identifiers in filenames, and are
+created with owner-only file permissions where the filesystem supports POSIX modes.
 
 If you use [`brew`](http://brew.sh) (MacOS or Linux), install `ffmpeg` using:
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Add a platform entry to your Homebridge `config.json`:
 | `audioBitrate` | No | `32` | Audio bitrate (kbps) |
 | `videoBitrate` | No | - | Cap video bitrate (kbps) |
 | `videoEncoder` | No | `auto` | Preferred FFmpeg video encoder; `auto` prefers platform hardware encoding and falls back to `libx264` |
+| `verifyImmisTls` | No | `true` | Verify TLS certificates and hostnames for Blink IMMIS live streams |
 | `debugStreamPath` | No | - | Save raw MPEG-TS stream recordings for debugging |
 | `snapshotCacheTTL` | No | `60` | Snapshot cache duration (seconds); `0` always fetches a new snapshot |
 | `persistSnapshotCache` | No | `false` | Keep the last snapshot indefinitely and expose a per-camera `Refresh Snapshot` switch in Home |
@@ -188,6 +189,11 @@ to `libx264` if the hardware encoder cannot be started.
 
 > [!NOTE]
 > The automatic encoder selection has been tested on a limited set of hardware (macOS with VideoToolbox and Raspberry Pi with V4L2). If you run into choppy streams, encoding errors, or unexpected fallback to software encoding on your platform, please [open an issue](https://github.com/sealad886/homebridge-blink-cameras-new-api/issues/new) with your hardware details and FFmpeg debug logs (`ffmpegDebug: true`).
+
+IMMIS live streams verify the upstream TLS certificate and hostname by default. Keep `verifyImmisTls: true`
+unless Blink support has confirmed your camera only exposes an insecure/self-signed stream endpoint. When
+`ffmpegDebug` is enabled, stream URLs and SRTP keys are redacted from logs. Debug recordings use hashed
+camera identifiers in filenames and are created with owner-only file permissions.
 
 If you use [`brew`](http://brew.sh) (MacOS or Linux), install `ffmpeg` using:
 

--- a/__tests__/accessories.test.ts
+++ b/__tests__/accessories.test.ts
@@ -443,15 +443,27 @@ describe('Accessory handlers', () => {
       const ffmpegProcess = spawnMock.mock.results[0]?.value as {
         stderr: { emit: (event: string, data: Buffer) => boolean };
       };
+      const firstUrlChunk = sensitiveUrl.slice(0, 45);
+      const secondUrlChunk = sensitiveUrl.slice(45);
+      ffmpegProcess.stderr.emit(
+        'data',
+        Buffer.from(`Opening '${firstUrlChunk}`),
+      );
+      let logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logs).not.toContain(firstUrlChunk);
+
       ffmpegProcess.stderr.emit(
         'data',
         Buffer.from(
-          `Opening '${sensitiveUrl}' for reading with -srtp_out_params video-srtp-secret ` +
-          'and srtp_in_params=audio-srtp-secret',
+          `${secondUrlChunk}' for reading with -srtp_out_params video-`,
         ),
       );
+      ffmpegProcess.stderr.emit(
+        'data',
+        Buffer.from('srtp-secret and srtp_in_params=audio-srtp-secret\n'),
+      );
 
-      const logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
+      logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
       expect(logs).toContain('<redacted>');
       expect(logs).not.toContain('client-secret');
       expect(logs).not.toContain('stream-secret');

--- a/__tests__/accessories.test.ts
+++ b/__tests__/accessories.test.ts
@@ -490,6 +490,88 @@ describe('Accessory handlers', () => {
     }
   });
 
+  it('omits overlong unterminated FFmpeg debug stderr lines', () => {
+    const hap = createHap();
+    const logFn = jest.fn();
+    const apiClient = {
+      requestCameraThumbnail: jest.fn(),
+      requestOwlThumbnail: jest.fn(),
+      requestDoorbellThumbnail: jest.fn(),
+      pollCommand: jest.fn(),
+    };
+    const spawnMock = spawn as unknown as jest.Mock;
+    spawnMock.mockClear();
+
+    try {
+      const source = new BlinkCameraSource(
+        apiClient as unknown as BlinkApi,
+        hap as unknown as HAP,
+        1,
+        2,
+        'camera',
+        'TEST_SERIAL',
+        jest.fn(),
+        () => true,
+        logFn,
+        { enabled: true, ffmpegDebug: true },
+      );
+
+      const session = {
+        address: '192.168.1.50',
+        addressVersion: 'ipv4',
+        sessionId: 'session',
+        videoPort: 5000,
+        localVideoPort: 5100,
+        localVideoRtcpPort: 5102,
+        videoCryptoSuite: hap.SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+        videoSRTP: Buffer.alloc(30, 1),
+        videoSSRC: 1234,
+      };
+      const request = {
+        type: 'start',
+        sessionID: 'session',
+        video: {
+          fps: 30,
+          width: 1280,
+          height: 720,
+          max_bit_rate: 300,
+          profile: hap.H264Profile.BASELINE,
+          level: hap.H264Level.LEVEL3_1,
+          pt: 99,
+          mtu: 1378,
+        },
+      };
+      const longSecretLine = `Opening immis://stream.immedia-semi.com/session/${'x'.repeat(70 * 1024)}?token=very-secret-token`;
+
+      (source as unknown as CameraSourcePrivateAccess).startFfmpegStream(
+        'session',
+        'immis://stream.immedia-semi.com/session/conn-secret?client_id=client-secret',
+        request,
+        session,
+        jest.fn(),
+      );
+
+      const ffmpegProcess = spawnMock.mock.results[0]?.value as {
+        stderr: { emit: (event: string, data: Buffer) => boolean };
+      };
+      logFn.mockClear();
+
+      ffmpegProcess.stderr.emit('data', Buffer.from(longSecretLine));
+      let logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logs).not.toContain('very-secret-token');
+      expect(logs).not.toContain('stderr line omitted');
+
+      ffmpegProcess.stderr.emit('data', Buffer.from('\nframe=2 done\n'));
+
+      logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logs).toContain('stderr line omitted because it exceeded 65536 characters');
+      expect(logs).toContain('FFmpeg(session): frame=2 done');
+      expect(logs).not.toContain('very-secret-token');
+    } finally {
+      spawnMock.mockClear();
+    }
+  });
+
   it('handles IMMIS proxy errors without leaving an unhandled stream error', async () => {
     const hap = createHap();
     const logFn = jest.fn();

--- a/__tests__/accessories.test.ts
+++ b/__tests__/accessories.test.ts
@@ -8,6 +8,7 @@ import { BlinkCamera, BlinkDoorbell, BlinkNetwork, BlinkOwl } from '../src/types
 import { createHap, createLogger, MockAccessory } from './helpers/homebridge';
 import { BlinkCameraSource, createCameraControllerOptions, resolveStreamingConfig } from '../src/accessories/camera-source';
 import { BlinkApi } from '../src/blink-api';
+import { ImmisProxyServer } from '../src/blink-api/immis-proxy';
 import { Buffer } from 'node:buffer';
 import { spawn } from 'node:child_process';
 
@@ -439,13 +440,108 @@ describe('Accessory handlers', () => {
         jest.fn(),
       );
 
+      const ffmpegProcess = spawnMock.mock.results[0]?.value as {
+        stderr: { emit: (event: string, data: Buffer) => boolean };
+      };
+      ffmpegProcess.stderr.emit(
+        'data',
+        Buffer.from(
+          `Opening '${sensitiveUrl}' for reading with -srtp_out_params video-srtp-secret ` +
+          'and srtp_in_params=audio-srtp-secret',
+        ),
+      );
+
       const logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
       expect(logs).toContain('<redacted>');
       expect(logs).not.toContain('client-secret');
       expect(logs).not.toContain('stream-secret');
       expect(logs).not.toContain('conn-secret');
+      expect(logs).not.toContain('video-srtp-secret');
+      expect(logs).not.toContain('audio-srtp-secret');
       expect(spawnMock).toHaveBeenCalledWith('ffmpeg', expect.arrayContaining(['-i', sensitiveUrl]));
     } finally {
+      spawnMock.mockClear();
+    }
+  });
+
+  it('handles IMMIS proxy errors without leaving an unhandled stream error', async () => {
+    const hap = createHap();
+    const logFn = jest.fn();
+    const apiClient = {
+      startCameraLiveview: jest.fn().mockResolvedValue({
+        server: 'immis://stream.immedia-semi.com/session/conn-secret?client_id=1',
+        command_id: 456,
+      }),
+      requestCameraThumbnail: jest.fn(),
+      requestOwlThumbnail: jest.fn(),
+      requestDoorbellThumbnail: jest.fn(),
+      getCommandStatus: jest.fn().mockResolvedValue({ status: 'running' }),
+      completeCommand: jest.fn().mockResolvedValue({}),
+    };
+    const startSpy = jest.spyOn(ImmisProxyServer.prototype, 'start').mockResolvedValue('tcp://127.0.0.1:1234');
+    const spawnMock = spawn as unknown as jest.Mock;
+    spawnMock.mockClear();
+
+    try {
+      const source = new BlinkCameraSource(
+        apiClient as unknown as BlinkApi,
+        hap as unknown as HAP,
+        1,
+        2,
+        'camera',
+        'TEST_SERIAL',
+        jest.fn(),
+        () => true,
+        logFn,
+        { enabled: true, ffmpegDebug: true },
+      );
+
+      const session = {
+        address: '192.168.1.50',
+        addressVersion: 'ipv4',
+        sessionId: 'session',
+        videoPort: 5000,
+        localVideoPort: 5100,
+        localVideoRtcpPort: 5102,
+        videoCryptoSuite: hap.SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+        videoSRTP: Buffer.alloc(30, 1),
+        videoSSRC: 1234,
+      };
+      (source as unknown as CameraSourcePrivateAccess).pendingSessions.set('session', session);
+
+      const callback = jest.fn();
+      await (source as unknown as CameraSourcePrivateAccess).startStream(
+        'session',
+        {
+          type: 'start',
+          sessionID: 'session',
+          video: {
+            fps: 30,
+            width: 1280,
+            height: 720,
+            max_bit_rate: 300,
+            profile: hap.H264Profile.BASELINE,
+            level: hap.H264Level.LEVEL3_1,
+            pt: 99,
+            mtu: 1378,
+          },
+        },
+        callback,
+      );
+
+      const active = (source as unknown as CameraSourcePrivateAccess).ongoingSessions.get('session') as {
+        immisProxy?: ImmisProxyServer;
+      };
+      const proxyError = new Error('certificate verify failed');
+      active.immisProxy?.emit('error', proxyError);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(startSpy).toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledWith(proxyError);
+      expect(logFn).toHaveBeenCalledWith(expect.stringContaining('IMMIS proxy error for session session'));
+      expect((source as unknown as CameraSourcePrivateAccess).ongoingSessions.has('session')).toBe(false);
+    } finally {
+      startSpy.mockRestore();
       spawnMock.mockClear();
     }
   });

--- a/__tests__/accessories.test.ts
+++ b/__tests__/accessories.test.ts
@@ -470,6 +470,20 @@ describe('Accessory handlers', () => {
       expect(logs).not.toContain('conn-secret');
       expect(logs).not.toContain('video-srtp-secret');
       expect(logs).not.toContain('audio-srtp-secret');
+
+      ffmpegProcess.stderr.emit(
+        'data',
+        Buffer.from(
+          `frame=1 input=${sensitiveUrl} -srtp_out_params progress-secret\r`,
+        ),
+      );
+
+      logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logs).toContain('FFmpeg(session): frame=1');
+      expect(logs).not.toContain('progress-secret');
+      expect(logs).not.toContain('client-secret');
+      expect(logs).not.toContain('stream-secret');
+      expect(logs).not.toContain('conn-secret');
       expect(spawnMock).toHaveBeenCalledWith('ffmpeg', expect.arrayContaining(['-i', sensitiveUrl]));
     } finally {
       spawnMock.mockClear();

--- a/__tests__/accessories.test.ts
+++ b/__tests__/accessories.test.ts
@@ -633,6 +633,74 @@ describe('Accessory handlers', () => {
     expect(privateSource.pendingSessions.has('new-session')).toBe(false);
   });
 
+  it('does not count stopping streams against maxStreams', async () => {
+    const hap = createHap();
+    const logFn = jest.fn();
+    const apiClient = {
+      startCameraLiveview: jest.fn().mockResolvedValue({ server: 'rtsp://example.com/live' }),
+      requestCameraThumbnail: jest.fn(),
+      requestOwlThumbnail: jest.fn(),
+      requestDoorbellThumbnail: jest.fn(),
+      pollCommand: jest.fn(),
+    };
+    const source = new BlinkCameraSource(
+      apiClient as unknown as BlinkApi,
+      hap as unknown as HAP,
+      1,
+      2,
+      'camera',
+      'TEST_SERIAL',
+      jest.fn(),
+      () => true,
+      logFn,
+      { enabled: true, maxStreams: 1 },
+    );
+    const spawnMock = spawn as unknown as jest.Mock;
+    spawnMock.mockClear();
+    const privateSource = source as unknown as CameraSourcePrivateAccess;
+    privateSource.pendingSessions.set('new-session', {
+      address: '192.168.1.50',
+      addressVersion: 'ipv4',
+      sessionId: 'new-session',
+      videoPort: 5000,
+      localVideoPort: 5100,
+      localVideoRtcpPort: 5102,
+      videoCryptoSuite: hap.SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+      videoSRTP: Buffer.alloc(30, 1),
+      videoSSRC: 1234,
+    });
+    privateSource.ongoingSessions.set('stopping-session', {
+      sessionId: 'stopping-session',
+      stopped: true,
+      localVideoPort: 5200,
+      localVideoRtcpPort: 5202,
+    });
+
+    const callback = jest.fn();
+    await privateSource.startStream('new-session', {
+      type: 'start',
+      sessionID: 'new-session',
+      video: {
+        fps: 30,
+        width: 1280,
+        height: 720,
+        max_bit_rate: 300,
+        profile: hap.H264Profile.BASELINE,
+        level: hap.H264Level.LEVEL3_1,
+        pt: 99,
+        mtu: 1378,
+      },
+    }, callback);
+
+    const ffmpegProcess = spawnMock.mock.results[0]?.value as { emit: (event: string) => boolean };
+    ffmpegProcess.emit('spawn');
+
+    expect(apiClient.startCameraLiveview).toHaveBeenCalledWith(1, 2);
+    expect(callback).toHaveBeenCalledWith();
+    expect(privateSource.pendingSessions.has('new-session')).toBe(false);
+    expect(privateSource.ongoingSessions.has('new-session')).toBe(true);
+  });
+
   it('advertises 30fps HomeKit streaming profiles for smoother playback', () => {
     const hap = createHap();
     const options = createCameraControllerOptions(

--- a/__tests__/accessories.test.ts
+++ b/__tests__/accessories.test.ts
@@ -9,10 +9,37 @@ import { createHap, createLogger, MockAccessory } from './helpers/homebridge';
 import { BlinkCameraSource, createCameraControllerOptions, resolveStreamingConfig } from '../src/accessories/camera-source';
 import { BlinkApi } from '../src/blink-api';
 import { Buffer } from 'node:buffer';
+import { spawn } from 'node:child_process';
+
+jest.mock('node:child_process', () => {
+  const actual = jest.requireActual('node:child_process') as typeof import('node:child_process');
+  const { EventEmitter: MockEventEmitter } = jest.requireActual('node:events') as typeof import('node:events');
+  return {
+    ...actual,
+    spawn: jest.fn(() => {
+      const process = new MockEventEmitter() as import('node:child_process').ChildProcessWithoutNullStreams;
+      process.stderr = new MockEventEmitter() as never;
+      process.kill = jest.fn() as never;
+      return process;
+    }),
+  };
+});
 
 type PlatformStub = Pick<BlinkCamerasPlatform, 'Service' | 'Characteristic' | 'apiClient' | 'log' | 'api' | 'streamingConfig'>;
 type CameraSourceFfmpegAccess = {
   buildFfmpegArgs: (input: string, request: unknown, session: unknown) => string[];
+};
+type CameraSourcePrivateAccess = CameraSourceFfmpegAccess & {
+  startFfmpegStream: (
+    sessionId: string,
+    input: string,
+    request: unknown,
+    session: unknown,
+    callback: (error?: Error) => void,
+  ) => void;
+  startStream: (sessionId: string, request: unknown, callback: (error?: Error) => void) => Promise<void>;
+  pendingSessions: Map<string, unknown>;
+  ongoingSessions: Map<string, unknown>;
 };
 
 describe('Accessory handlers', () => {
@@ -349,6 +376,139 @@ describe('Accessory handlers', () => {
     expect(argString).not.toContain('-preset veryfast');
     expect(argString).not.toContain('-profile:v high');
     expect(argString).not.toContain('-level:v 4.0');
+  });
+
+  it('redacts live stream URLs from stream start and FFmpeg debug logs', () => {
+    const hap = createHap();
+    const logFn = jest.fn();
+    const apiClient = {
+      requestCameraThumbnail: jest.fn(),
+      requestOwlThumbnail: jest.fn(),
+      requestDoorbellThumbnail: jest.fn(),
+      pollCommand: jest.fn(),
+    };
+    const spawnMock = spawn as unknown as jest.Mock;
+    spawnMock.mockClear();
+
+    try {
+      const source = new BlinkCameraSource(
+        apiClient as unknown as BlinkApi,
+        hap as unknown as HAP,
+        1,
+        2,
+        'camera',
+        'TEST_SERIAL',
+        jest.fn(),
+        () => true,
+        logFn,
+        { enabled: true, ffmpegDebug: true },
+      );
+
+      const session = {
+        address: '192.168.1.50',
+        addressVersion: 'ipv4',
+        sessionId: 'session',
+        videoPort: 5000,
+        localVideoPort: 5100,
+        localVideoRtcpPort: 5102,
+        videoCryptoSuite: hap.SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+        videoSRTP: Buffer.alloc(30, 1),
+        videoSSRC: 1234,
+      };
+      const request = {
+        type: 'start',
+        sessionID: 'session',
+        video: {
+          fps: 30,
+          width: 1280,
+          height: 720,
+          max_bit_rate: 300,
+          profile: hap.H264Profile.BASELINE,
+          level: hap.H264Level.LEVEL3_1,
+          pt: 99,
+          mtu: 1378,
+        },
+      };
+      const sensitiveUrl = 'immis://stream.immedia-semi.com/session/conn-secret?client_id=client-secret&token=stream-secret';
+
+      (source as unknown as CameraSourcePrivateAccess).startFfmpegStream(
+        'session',
+        sensitiveUrl,
+        request,
+        session,
+        jest.fn(),
+      );
+
+      const logs = logFn.mock.calls.map((call) => String(call[0])).join('\n');
+      expect(logs).toContain('<redacted>');
+      expect(logs).not.toContain('client-secret');
+      expect(logs).not.toContain('stream-secret');
+      expect(logs).not.toContain('conn-secret');
+      expect(spawnMock).toHaveBeenCalledWith('ffmpeg', expect.arrayContaining(['-i', sensitiveUrl]));
+    } finally {
+      spawnMock.mockClear();
+    }
+  });
+
+  it('rejects stream starts beyond configured maxStreams before requesting live view', async () => {
+    const hap = createHap();
+    const logFn = jest.fn();
+    const apiClient = {
+      startCameraLiveview: jest.fn().mockResolvedValue({ server: 'rtsp://example.com/live' }),
+      requestCameraThumbnail: jest.fn(),
+      requestOwlThumbnail: jest.fn(),
+      requestDoorbellThumbnail: jest.fn(),
+      pollCommand: jest.fn(),
+    };
+    const source = new BlinkCameraSource(
+      apiClient as unknown as BlinkApi,
+      hap as unknown as HAP,
+      1,
+      2,
+      'camera',
+      'TEST_SERIAL',
+      jest.fn(),
+      () => true,
+      logFn,
+      { enabled: true, maxStreams: 1 },
+    );
+    const privateSource = source as unknown as CameraSourcePrivateAccess;
+    privateSource.pendingSessions.set('new-session', {
+      address: '192.168.1.50',
+      addressVersion: 'ipv4',
+      sessionId: 'new-session',
+      videoPort: 5000,
+      localVideoPort: 5100,
+      localVideoRtcpPort: 5102,
+      videoCryptoSuite: hap.SRTPCryptoSuites.AES_CM_128_HMAC_SHA1_80,
+      videoSRTP: Buffer.alloc(30, 1),
+      videoSSRC: 1234,
+    });
+    privateSource.ongoingSessions.set('existing-session', {
+      sessionId: 'existing-session',
+      localVideoPort: 5200,
+      localVideoRtcpPort: 5202,
+    });
+
+    const callback = jest.fn();
+    await privateSource.startStream('new-session', {
+      type: 'start',
+      sessionID: 'new-session',
+      video: {
+        fps: 30,
+        width: 1280,
+        height: 720,
+        max_bit_rate: 300,
+        profile: hap.H264Profile.BASELINE,
+        level: hap.H264Level.LEVEL3_1,
+        pt: 99,
+        mtu: 1378,
+      },
+    }, callback);
+
+    expect(callback).toHaveBeenCalledWith(expect.any(Error));
+    expect(apiClient.startCameraLiveview).not.toHaveBeenCalled();
+    expect(privateSource.pendingSessions.has('new-session')).toBe(false);
   });
 
   it('advertises 30fps HomeKit streaming profiles for smoother playback', () => {

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -493,6 +493,22 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     }
   });
 
+  it('load() rejects symlinked auth files before hardening permissions', async () => {
+    const targetPath = path.join(tmpDir, 'target-auth-state.json');
+    await fs.writeFile(targetPath, JSON.stringify(sampleState, null, 2), 'utf8');
+    await fs.symlink(targetPath, dotFilePath);
+    const chmodSpy = jest.spyOn(fs, 'chmod');
+
+    try {
+      const storage = getStorage(makeAuth());
+
+      await expect(storage.load()).rejects.toThrow('symlinked auth state file');
+      expect(chmodSpy).not.toHaveBeenCalled();
+    } finally {
+      chmodSpy.mockRestore();
+    }
+  });
+
   it('load() returns null when no file exists', async () => {
     const storage = getStorage(makeAuth());
     const loaded = await storage.load();

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -481,13 +481,14 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     expect(stats.mode & 0o777).toBe(0o600);
   });
 
-  it('load() still returns state when an already owner-only file cannot be chmodded', async () => {
+  it('load() returns already owner-only state without chmodding', async () => {
     await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
     await fs.chmod(dotFilePath, 0o600);
     const realOpen = fs.open.bind(fs);
+    const chmodMocks: Array<jest.SpiedFunction<Awaited<ReturnType<typeof fs.open>>['chmod']>> = [];
     const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
       const handle = await realOpen(filePath, flags, mode);
-      jest.spyOn(handle, 'chmod').mockRejectedValueOnce(new Error('chmod unsupported'));
+      chmodMocks.push(jest.spyOn(handle, 'chmod').mockRejectedValueOnce(new Error('chmod unsupported')));
       return handle;
     });
 
@@ -497,6 +498,8 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
 
       expect(loaded).toEqual(sampleState);
       expect(openSpy).toHaveBeenCalledWith(dotFilePath, expect.any(Number));
+      expect(chmodMocks).toHaveLength(1);
+      expect(chmodMocks[0]).not.toHaveBeenCalled();
     } finally {
       openSpy.mockRestore();
     }

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -462,6 +462,23 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     expect(stats.mode & 0o777).toBe(0o600);
   });
 
+  it('save() replaces existing auth state during token refresh', async () => {
+    const storage = getStorage(makeAuth());
+    const refreshedState = {
+      ...sampleState,
+      accessToken: 'refreshed-access-token',
+      refreshToken: 'refreshed-refresh-token',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    };
+
+    await storage.save(sampleState);
+    await storage.save(refreshedState);
+
+    const raw = await fs.readFile(dotFilePath, 'utf8');
+    expect(JSON.parse(raw)).toEqual(refreshedState);
+    expect(await fs.readdir(tmpDir)).toEqual(['.blink-auth-state.json']);
+  });
+
   it('load() reads state from the dot-file path', async () => {
     await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
 

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -1,4 +1,9 @@
-import { BlinkAuth, Blink2FARequiredError, BlinkAuthenticationError } from '../../src/blink-api/auth';
+import {
+  AuthStateFileSecurityError,
+  BlinkAuth,
+  Blink2FARequiredError,
+  BlinkAuthenticationError,
+} from '../../src/blink-api/auth';
 import { BlinkAuthState, BlinkAuthStorage, BlinkConfig } from '../../src/types';
 import { URL } from 'node:url';
 import { promises as fs } from 'node:fs';
@@ -476,8 +481,9 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     expect(stats.mode & 0o777).toBe(0o600);
   });
 
-  it('load() still returns state when permission hardening is unsupported', async () => {
+  it('load() still returns state when an already owner-only file cannot be chmodded', async () => {
     await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
+    await fs.chmod(dotFilePath, 0o600);
     const realOpen = fs.open.bind(fs);
     const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
       const handle = await realOpen(filePath, flags, mode);
@@ -491,6 +497,28 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
 
       expect(loaded).toEqual(sampleState);
       expect(openSpy).toHaveBeenCalledWith(dotFilePath, expect.any(Number));
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+
+  const itIfPosix = process.platform === 'win32' ? it.skip : it;
+
+  itIfPosix('load() rejects shared-readable auth files when POSIX permission hardening fails', async () => {
+    await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
+    await fs.chmod(dotFilePath, 0o644);
+    const realOpen = fs.open.bind(fs);
+    const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
+      const handle = await realOpen(filePath, flags, mode);
+      jest.spyOn(handle, 'chmod').mockRejectedValueOnce(new Error('chmod denied'));
+      return handle;
+    });
+
+    try {
+      const storage = getStorage(makeAuth());
+
+      await expect(storage.load()).rejects.toThrow(AuthStateFileSecurityError);
+      await expect(storage.load()).rejects.toThrow('could not be tightened to 0600');
     } finally {
       openSpy.mockRestore();
     }

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -478,18 +478,21 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
 
   it('load() still returns state when permission hardening is unsupported', async () => {
     await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
-    const chmodSpy = jest
-      .spyOn(fs, 'chmod')
-      .mockRejectedValueOnce(new Error('chmod unsupported'));
+    const realOpen = fs.open.bind(fs);
+    const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
+      const handle = await realOpen(filePath, flags, mode);
+      jest.spyOn(handle, 'chmod').mockRejectedValueOnce(new Error('chmod unsupported'));
+      return handle;
+    });
 
     try {
       const storage = getStorage(makeAuth());
       const loaded = await storage.load();
 
       expect(loaded).toEqual(sampleState);
-      expect(chmodSpy).toHaveBeenCalledWith(dotFilePath, 0o600);
+      expect(openSpy).toHaveBeenCalledWith(dotFilePath, expect.any(Number));
     } finally {
-      chmodSpy.mockRestore();
+      openSpy.mockRestore();
     }
   });
 
@@ -507,6 +510,19 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     } finally {
       chmodSpy.mockRestore();
     }
+  });
+
+  it('save() replaces a symlinked auth path without writing through it', async () => {
+    const targetPath = path.join(tmpDir, 'target-auth-state.json');
+    await fs.writeFile(targetPath, 'do-not-overwrite', 'utf8');
+    await fs.symlink(targetPath, dotFilePath);
+
+    const storage = getStorage(makeAuth());
+    await storage.save(sampleState);
+
+    expect(await fs.readFile(targetPath, 'utf8')).toBe('do-not-overwrite');
+    expect((await fs.lstat(dotFilePath)).isSymbolicLink()).toBe(false);
+    expect(JSON.parse(await fs.readFile(dotFilePath, 'utf8'))).toEqual(sampleState);
   });
 
   it('load() returns null when no file exists', async () => {

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -476,6 +476,23 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     expect(stats.mode & 0o777).toBe(0o600);
   });
 
+  it('load() still returns state when permission hardening is unsupported', async () => {
+    await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
+    const chmodSpy = jest
+      .spyOn(fs, 'chmod')
+      .mockRejectedValueOnce(new Error('chmod unsupported'));
+
+    try {
+      const storage = getStorage(makeAuth());
+      const loaded = await storage.load();
+
+      expect(loaded).toEqual(sampleState);
+      expect(chmodSpy).toHaveBeenCalledWith(dotFilePath, 0o600);
+    } finally {
+      chmodSpy.mockRestore();
+    }
+  });
+
   it('load() returns null when no file exists', async () => {
     const storage = getStorage(makeAuth());
     const loaded = await storage.load();

--- a/__tests__/blink-api/auth.test.ts
+++ b/__tests__/blink-api/auth.test.ts
@@ -465,6 +465,17 @@ describe('FileAuthStorage via BlinkAuth persistence', () => {
     expect(loaded).toEqual(sampleState);
   });
 
+  it('load() hardens an existing primary auth file to owner-only permissions', async () => {
+    await fs.writeFile(dotFilePath, JSON.stringify(sampleState, null, 2), 'utf8');
+    await fs.chmod(dotFilePath, 0o644);
+
+    const storage = getStorage(makeAuth());
+    await storage.load();
+
+    const stats = await fs.stat(dotFilePath);
+    expect(stats.mode & 0o777).toBe(0o600);
+  });
+
   it('load() returns null when no file exists', async () => {
     const storage = getStorage(makeAuth());
     const loaded = await storage.load();

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -138,7 +138,7 @@ describe('ImmisProxyServer security controls', () => {
     });
 
     try {
-      (proxy as unknown as { startStreamRecording: () => void }).startStreamRecording();
+      await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
       const streamFile = (proxy as unknown as { streamFile: WriteStream | null }).streamFile;
       expect(streamFile).toBeTruthy();
 

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -1,5 +1,32 @@
 import { parseLatmFrames, ImmisProxyServer } from '../../src/blink-api/immis-proxy';
 import { EventEmitter } from 'node:events';
+import { promises as fs } from 'node:fs';
+import type { WriteStream } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as tls from 'node:tls';
+
+jest.mock('node:tls', () => {
+  const actual = jest.requireActual('node:tls') as typeof import('node:tls');
+  const { EventEmitter: MockEventEmitter } = jest.requireActual('node:events') as typeof import('node:events');
+  return {
+    ...actual,
+    connect: jest.fn((_options: tls.ConnectionOptions, callback?: () => void) => {
+      const socket = new MockEventEmitter() as tls.TLSSocket & {
+        write: jest.Mock;
+        destroyed: boolean;
+        destroy: jest.Mock;
+      };
+      socket.write = jest.fn();
+      socket.destroyed = false;
+      socket.destroy = jest.fn();
+      if (callback) {
+        setImmediate(callback);
+      }
+      return socket;
+    }),
+  };
+});
 
 const buildLoasFrame = (payload: Buffer): Buffer => {
   const length = payload.length;
@@ -66,6 +93,69 @@ describe('ImmisProxyServer idle reconnect grace', () => {
     if (idleShutdownTimeout) {
       clearTimeout(idleShutdownTimeout);
       (proxy as unknown as { idleShutdownTimeout: null }).idleShutdownTimeout = null;
+    }
+  });
+});
+
+describe('ImmisProxyServer security controls', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('verifies upstream IMMIS TLS by default', async () => {
+    const connectMock = tls.connect as unknown as jest.Mock;
+    connectMock.mockClear();
+
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+    });
+
+    (proxy as unknown as { connectToImmisServer: () => void }).connectToImmisServer();
+
+    expect(connectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'stream.immedia-semi.com',
+        port: 443,
+        rejectUnauthorized: true,
+        servername: 'stream.immedia-semi.com',
+        minVersion: 'TLSv1.2',
+      }),
+      expect.any(Function),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    (proxy as unknown as { isRunning: boolean }).isRunning = true;
+    proxy.stop();
+  });
+
+  it('keeps debug stream recordings owner-only and omits raw serials from filenames', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+    });
+
+    try {
+      (proxy as unknown as { startStreamRecording: () => void }).startStreamRecording();
+      const streamFile = (proxy as unknown as { streamFile: WriteStream | null }).streamFile;
+      expect(streamFile).toBeTruthy();
+
+      const filename = path.basename(String(streamFile?.path));
+      expect(filename).not.toContain('TEST_SERIAL');
+      expect(filename).toMatch(/^blink-stream-[a-f0-9]{16}-/);
+
+      await new Promise<void>((resolve, reject) => {
+        streamFile?.once('open', () => resolve());
+        streamFile?.once('error', reject);
+      });
+      const stats = await fs.stat(String(streamFile?.path));
+      expect(stats.mode & 0o777).toBe(0o600);
+      await new Promise<void>((resolve) => streamFile?.end(resolve));
+    } finally {
+      (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
 });

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -181,7 +181,11 @@ describe('ImmisProxyServer security controls', () => {
       });
       const stats = await fs.stat(String(streamFile?.path));
       expect(stats.mode & 0o777).toBe(0o600);
-      const dirStats = await fs.stat(tmpDir);
+      const rootStats = await fs.stat(tmpDir);
+      expect(rootStats.mode & 0o777).toBe(0o755);
+      const recordingDir = path.dirname(String(streamFile?.path));
+      expect(path.basename(recordingDir)).toBe('blink-stream-recordings');
+      const dirStats = await fs.stat(recordingDir);
       expect(dirStats.mode & 0o777).toBe(0o700);
       await new Promise<void>((resolve) => streamFile?.end(resolve));
     } finally {

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -175,10 +175,6 @@ describe('ImmisProxyServer security controls', () => {
       expect(filename).not.toContain('TEST_SERIAL');
       expect(filename).toMatch(/^blink-stream-[a-f0-9]{16}-.+-[a-f0-9]{16}\.ts$/);
 
-      await new Promise<void>((resolve, reject) => {
-        streamFile?.once('open', () => resolve());
-        streamFile?.once('error', reject);
-      });
       const stats = await fs.stat(String(streamFile?.path));
       expect(stats.mode & 0o777).toBe(0o600);
       const rootStats = await fs.stat(tmpDir);
@@ -262,10 +258,6 @@ describe('ImmisProxyServer security controls', () => {
         expect.stringContaining('Failed to set debug recording directory permissions'),
       );
 
-      await new Promise<void>((resolve, reject) => {
-        streamFile?.once('open', () => resolve());
-        streamFile?.once('error', reject);
-      });
       await new Promise<void>((resolve) => streamFile?.end(resolve));
     } finally {
       (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
@@ -292,6 +284,44 @@ describe('ImmisProxyServer security controls', () => {
       expect((proxy as unknown as { streamFile: WriteStream | null }).streamFile).toBeNull();
       expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to start stream recording'));
     } finally {
+      (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects debug stream recording directory swaps before using the capture file', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const recordingDir = path.join(tmpDir, 'blink-stream-recordings');
+    const targetDir = path.join(tmpDir, 'target');
+    const log = jest.fn();
+    const realLstat = fs.lstat.bind(fs);
+    let recordingDirLstatCount = 0;
+    const lstatSpy = jest.spyOn(fs, 'lstat').mockImplementation(async (filePath) => {
+      if (String(filePath) === recordingDir) {
+        recordingDirLstatCount += 1;
+        if (recordingDirLstatCount === 2) {
+          await fs.rm(recordingDir, { recursive: true, force: true });
+          await fs.mkdir(targetDir, { recursive: true });
+          await fs.symlink(targetDir, recordingDir, 'dir');
+        }
+      }
+      return realLstat(filePath);
+    });
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+      log,
+    });
+
+    try {
+      await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      expect((proxy as unknown as { streamFile: WriteStream | null }).streamFile).toBeNull();
+      expect(lstatSpy).toHaveBeenCalledWith(recordingDir);
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to start stream recording'));
+      expect(await fs.readdir(targetDir)).toHaveLength(0);
+    } finally {
+      lstatSpy.mockRestore();
       (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -384,6 +384,46 @@ describe('ImmisProxyServer security controls', () => {
     }
   });
 
+  it('does not unlink an existing recording file when exclusive open fails before creation', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const log = jest.fn();
+    let attemptedFilename: string | null = null;
+    const nodeFs = jest.requireActual<typeof import('node:fs')>('node:fs');
+    const openSpy = jest.spyOn(nodeFs, 'open').mockImplementation(
+      ((filePath, _flags, modeOrCallback, maybeCallback) => {
+        const callback = typeof modeOrCallback === 'function' ? modeOrCallback : maybeCallback;
+        if (!callback) {
+          throw new Error('fs.open callback missing');
+        }
+        attemptedFilename = String(filePath);
+        void fs.mkdir(path.dirname(attemptedFilename), { recursive: true })
+          .then(() => fs.writeFile(String(attemptedFilename), 'existing recording', 'utf8'))
+          .then(() => {
+            const error = Object.assign(new Error('recording already exists'), { code: 'EEXIST' });
+            callback(error, 0);
+          });
+      }) as typeof nodeFs.open,
+    );
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+      log,
+    });
+
+    try {
+      await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      expect((proxy as unknown as { streamFile: WriteStream | null }).streamFile).toBeNull();
+      expect(attemptedFilename).toBeTruthy();
+      await expect(fs.readFile(String(attemptedFilename), 'utf8')).resolves.toBe('existing recording');
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to start stream recording'));
+    } finally {
+      openSpy.mockRestore();
+      (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('redacts IMMIS auth identifiers from proxy debug logs', () => {
     const log = jest.fn();
     const proxy = new ImmisProxyServer({

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -241,7 +241,16 @@ describe('ImmisProxyServer security controls', () => {
   it('continues debug stream recording when directory chmod is unsupported', async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
     const log = jest.fn();
-    const chmodSpy = jest.spyOn(fs, 'chmod').mockRejectedValueOnce(new Error('chmod unsupported'));
+    const realOpen = fs.open.bind(fs);
+    const dirHandleChmod = jest.fn().mockRejectedValueOnce(new Error('chmod unsupported'));
+    const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
+      const handle = await realOpen(filePath, flags, mode);
+      if (String(filePath).endsWith('blink-stream-recordings')) {
+        jest.spyOn(handle, 'chmod').mockImplementation(dirHandleChmod);
+      }
+      return handle;
+    });
+    const pathChmodSpy = jest.spyOn(fs, 'chmod');
     const proxy = new ImmisProxyServer({
       immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
       serial: 'TEST_SERIAL',
@@ -253,13 +262,16 @@ describe('ImmisProxyServer security controls', () => {
       await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
       const streamFile = (proxy as unknown as { streamFile: WriteStream | null }).streamFile;
       expect(streamFile).toBeTruthy();
-      expect(chmodSpy).toHaveBeenCalledWith(expect.stringContaining('blink-stream-recordings'), 0o700);
+      expect(dirHandleChmod).toHaveBeenCalledWith(0o700);
+      expect(pathChmodSpy).not.toHaveBeenCalledWith(expect.stringContaining('blink-stream-recordings'), 0o700);
       expect(log).toHaveBeenCalledWith(
         expect.stringContaining('Failed to set debug recording directory permissions'),
       );
 
       await new Promise<void>((resolve) => streamFile?.end(resolve));
     } finally {
+      openSpy.mockRestore();
+      pathChmodSpy.mockRestore();
       (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
@@ -299,7 +311,7 @@ describe('ImmisProxyServer security controls', () => {
     const lstatSpy = jest.spyOn(fs, 'lstat').mockImplementation(async (filePath) => {
       if (String(filePath) === recordingDir) {
         recordingDirLstatCount += 1;
-        if (recordingDirLstatCount === 2) {
+        if (recordingDirLstatCount === 1) {
           await fs.rm(recordingDir, { recursive: true, force: true });
           await fs.mkdir(targetDir, { recursive: true });
           await fs.symlink(targetDir, recordingDir, 'dir');

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -339,6 +339,51 @@ describe('ImmisProxyServer security controls', () => {
     }
   });
 
+  it('does not chmod a swapped debug recording directory before verifying its identity', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const recordingDir = path.join(tmpDir, 'blink-stream-recordings');
+    const targetDir = path.join(tmpDir, 'target');
+    const log = jest.fn();
+    const realLstat = fs.lstat.bind(fs);
+    const realOpen = fs.open.bind(fs);
+    const dirHandleChmod = jest.fn();
+    const lstatSpy = jest.spyOn(fs, 'lstat').mockImplementation(async (filePath) => {
+      const stats = await realLstat(filePath);
+      if (String(filePath) === recordingDir) {
+        await fs.rm(recordingDir, { recursive: true, force: true });
+        await fs.mkdir(targetDir, { recursive: true });
+        await fs.symlink(targetDir, recordingDir, 'dir');
+      }
+      return stats;
+    });
+    const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
+      if (String(filePath) === recordingDir) {
+        const handle = await realOpen(targetDir, flags, mode);
+        jest.spyOn(handle, 'chmod').mockImplementation(dirHandleChmod);
+        return handle;
+      }
+      return realOpen(filePath, flags, mode);
+    });
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+      log,
+    });
+
+    try {
+      await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      expect((proxy as unknown as { streamFile: WriteStream | null }).streamFile).toBeNull();
+      expect(dirHandleChmod).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to start stream recording'));
+    } finally {
+      lstatSpy.mockRestore();
+      openSpy.mockRestore();
+      (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('redacts IMMIS auth identifiers from proxy debug logs', () => {
     const log = jest.fn();
     const proxy = new ImmisProxyServer({

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -1,7 +1,7 @@
 import { parseLatmFrames, ImmisProxyServer } from '../../src/blink-api/immis-proxy';
 import { EventEmitter } from 'node:events';
 import { promises as fs } from 'node:fs';
-import type { Stats, WriteStream } from 'node:fs';
+import type { WriteStream } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as tls from 'node:tls';
@@ -35,12 +35,6 @@ const buildLoasFrame = (payload: Buffer): Buffer => {
   header[1] = 0xe0 | ((length >> 8) & 0x1f);
   header[2] = length & 0xff;
   return Buffer.concat([header, payload]);
-};
-
-type FsStats = Stats;
-
-const cloneStats = (stats: FsStats, overrides: Partial<FsStats>): FsStats => {
-  return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, overrides);
 };
 
 describe('parseLatmFrames', () => {
@@ -353,13 +347,11 @@ describe('ImmisProxyServer security controls', () => {
     const realLstat = fs.lstat.bind(fs);
     const realOpen = fs.open.bind(fs);
     const dirHandleChmod = jest.fn();
-    let originalRecordingDirStats: FsStats | null = null;
+    await fs.mkdir(targetDir, { recursive: true });
     const lstatSpy = jest.spyOn(fs, 'lstat').mockImplementation(async (filePath) => {
-      const stats = await realLstat(filePath) as FsStats;
+      const stats = await realLstat(filePath);
       if (String(filePath) === recordingDir) {
-        originalRecordingDirStats = stats;
         await fs.rm(recordingDir, { recursive: true, force: true });
-        await fs.mkdir(targetDir, { recursive: true });
         await fs.symlink(targetDir, recordingDir, 'dir');
       }
       return stats;
@@ -367,20 +359,6 @@ describe('ImmisProxyServer security controls', () => {
     const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
       if (String(filePath) === recordingDir) {
         const handle = await realOpen(targetDir, flags, mode);
-        const realHandleStat = handle.stat.bind(handle);
-        jest.spyOn(handle, 'stat').mockImplementation(async () => {
-          const targetStats = await realHandleStat() as FsStats;
-          if (!originalRecordingDirStats) {
-            return targetStats;
-          }
-          return cloneStats(targetStats, {
-            dev: originalRecordingDirStats.dev,
-            ino: originalRecordingDirStats.ino,
-            ctimeMs: originalRecordingDirStats.ctimeMs + 1,
-            mtimeMs: originalRecordingDirStats.mtimeMs + 1,
-            birthtimeMs: originalRecordingDirStats.birthtimeMs + 1,
-          });
-        });
         jest.spyOn(handle, 'chmod').mockImplementation(dirHandleChmod);
         return handle;
       }

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -173,7 +173,7 @@ describe('ImmisProxyServer security controls', () => {
 
       const filename = path.basename(String(streamFile?.path));
       expect(filename).not.toContain('TEST_SERIAL');
-      expect(filename).toMatch(/^blink-stream-[a-f0-9]{16}-/);
+      expect(filename).toMatch(/^blink-stream-[a-f0-9]{16}-.+-[a-f0-9]{16}\.ts$/);
 
       await new Promise<void>((resolve, reject) => {
         streamFile?.once('open', () => resolve());
@@ -190,6 +190,54 @@ describe('ImmisProxyServer security controls', () => {
       await new Promise<void>((resolve) => streamFile?.end(resolve));
     } finally {
       (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses collision-resistant debug stream recording filenames for same-timestamp viewers', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const timestampSpy = jest
+      .spyOn(Date.prototype, 'toISOString')
+      .mockReturnValue('2026-05-05T21:00:00.000Z');
+    const proxyA = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+    });
+    const proxyB = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+    });
+
+    try {
+      await (proxyA as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      await (proxyB as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      const streamFileA = (proxyA as unknown as { streamFile: WriteStream | null }).streamFile;
+      const streamFileB = (proxyB as unknown as { streamFile: WriteStream | null }).streamFile;
+      expect(streamFileA).toBeTruthy();
+      expect(streamFileB).toBeTruthy();
+
+      const filenameA = path.basename(String(streamFileA?.path));
+      const filenameB = path.basename(String(streamFileB?.path));
+      expect(filenameA).toMatch(/^blink-stream-[a-f0-9]{16}-2026-05-05T21-00-00-000Z-[a-f0-9]{16}\.ts$/);
+      expect(filenameB).toMatch(/^blink-stream-[a-f0-9]{16}-2026-05-05T21-00-00-000Z-[a-f0-9]{16}\.ts$/);
+      expect(filenameA).not.toBe(filenameB);
+
+      await Promise.all([
+        new Promise<void>((resolve, reject) => {
+          streamFileA?.once('error', reject);
+          streamFileA?.end(resolve);
+        }),
+        new Promise<void>((resolve, reject) => {
+          streamFileB?.once('error', reject);
+          streamFileB?.end(resolve);
+        }),
+      ]);
+    } finally {
+      timestampSpy.mockRestore();
+      (proxyA as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      (proxyB as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -129,8 +129,37 @@ describe('ImmisProxyServer security controls', () => {
     proxy.stop();
   });
 
+  it('allows upstream IMMIS TLS verification to be disabled explicitly', async () => {
+    const connectMock = tls.connect as unknown as jest.Mock;
+    connectMock.mockClear();
+
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      verifyTls: false,
+    });
+
+    (proxy as unknown as { connectToImmisServer: () => void }).connectToImmisServer();
+
+    expect(connectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: 'stream.immedia-semi.com',
+        port: 443,
+        rejectUnauthorized: false,
+        servername: 'stream.immedia-semi.com',
+        minVersion: 'TLSv1.2',
+      }),
+      expect.any(Function),
+    );
+
+    await new Promise((resolve) => setImmediate(resolve));
+    (proxy as unknown as { isRunning: boolean }).isRunning = true;
+    proxy.stop();
+  });
+
   it('keeps debug stream recordings owner-only and omits raw serials from filenames', async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    await fs.chmod(tmpDir, 0o755);
     const proxy = new ImmisProxyServer({
       immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
       serial: 'TEST_SERIAL',
@@ -152,10 +181,30 @@ describe('ImmisProxyServer security controls', () => {
       });
       const stats = await fs.stat(String(streamFile?.path));
       expect(stats.mode & 0o777).toBe(0o600);
+      const dirStats = await fs.stat(tmpDir);
+      expect(dirStats.mode & 0o777).toBe(0o700);
       await new Promise<void>((resolve) => streamFile?.end(resolve));
     } finally {
       (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it('redacts IMMIS auth identifiers from proxy debug logs', () => {
+    const log = jest.fn();
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session/conn-secret__suffix?client_id=12345',
+      serial: 'TEST_SERIAL',
+      debug: true,
+      log,
+    });
+
+    (proxy as unknown as { buildAuthHeader: () => Buffer }).buildAuthHeader();
+
+    const logs = log.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(logs).toContain('Client ID: <redacted>');
+    expect(logs).toContain('Connection ID: <redacted>');
+    expect(logs).not.toContain('12345');
+    expect(logs).not.toContain('conn-secret');
   });
 });

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -194,6 +194,37 @@ describe('ImmisProxyServer security controls', () => {
     }
   });
 
+  it('continues debug stream recording when directory chmod is unsupported', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const log = jest.fn();
+    const chmodSpy = jest.spyOn(fs, 'chmod').mockRejectedValueOnce(new Error('chmod unsupported'));
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+      log,
+    });
+
+    try {
+      await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      const streamFile = (proxy as unknown as { streamFile: WriteStream | null }).streamFile;
+      expect(streamFile).toBeTruthy();
+      expect(chmodSpy).toHaveBeenCalledWith(expect.stringContaining('blink-stream-recordings'), 0o700);
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to set debug recording directory permissions'),
+      );
+
+      await new Promise<void>((resolve, reject) => {
+        streamFile?.once('open', () => resolve());
+        streamFile?.once('error', reject);
+      });
+      await new Promise<void>((resolve) => streamFile?.end(resolve));
+    } finally {
+      (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('redacts IMMIS auth identifiers from proxy debug logs', () => {
     const log = jest.fn();
     const proxy = new ImmisProxyServer({

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -1,7 +1,7 @@
 import { parseLatmFrames, ImmisProxyServer } from '../../src/blink-api/immis-proxy';
 import { EventEmitter } from 'node:events';
 import { promises as fs } from 'node:fs';
-import type { WriteStream } from 'node:fs';
+import type { Stats, WriteStream } from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import * as tls from 'node:tls';
@@ -35,6 +35,12 @@ const buildLoasFrame = (payload: Buffer): Buffer => {
   header[1] = 0xe0 | ((length >> 8) & 0x1f);
   header[2] = length & 0xff;
   return Buffer.concat([header, payload]);
+};
+
+type FsStats = Stats;
+
+const cloneStats = (stats: FsStats, overrides: Partial<FsStats>): FsStats => {
+  return Object.assign(Object.create(Object.getPrototypeOf(stats)), stats, overrides);
 };
 
 describe('parseLatmFrames', () => {
@@ -347,9 +353,11 @@ describe('ImmisProxyServer security controls', () => {
     const realLstat = fs.lstat.bind(fs);
     const realOpen = fs.open.bind(fs);
     const dirHandleChmod = jest.fn();
+    let originalRecordingDirStats: FsStats | null = null;
     const lstatSpy = jest.spyOn(fs, 'lstat').mockImplementation(async (filePath) => {
-      const stats = await realLstat(filePath);
+      const stats = await realLstat(filePath) as FsStats;
       if (String(filePath) === recordingDir) {
+        originalRecordingDirStats = stats;
         await fs.rm(recordingDir, { recursive: true, force: true });
         await fs.mkdir(targetDir, { recursive: true });
         await fs.symlink(targetDir, recordingDir, 'dir');
@@ -359,6 +367,20 @@ describe('ImmisProxyServer security controls', () => {
     const openSpy = jest.spyOn(fs, 'open').mockImplementation(async (filePath, flags, mode) => {
       if (String(filePath) === recordingDir) {
         const handle = await realOpen(targetDir, flags, mode);
+        const realHandleStat = handle.stat.bind(handle);
+        jest.spyOn(handle, 'stat').mockImplementation(async () => {
+          const targetStats = await realHandleStat() as FsStats;
+          if (!originalRecordingDirStats) {
+            return targetStats;
+          }
+          return cloneStats(targetStats, {
+            dev: originalRecordingDirStats.dev,
+            ino: originalRecordingDirStats.ino,
+            ctimeMs: originalRecordingDirStats.ctimeMs + 1,
+            mtimeMs: originalRecordingDirStats.mtimeMs + 1,
+            birthtimeMs: originalRecordingDirStats.birthtimeMs + 1,
+          });
+        });
         jest.spyOn(handle, 'chmod').mockImplementation(dirHandleChmod);
         return handle;
       }

--- a/__tests__/blink-api/immis-proxy.test.ts
+++ b/__tests__/blink-api/immis-proxy.test.ts
@@ -225,6 +225,30 @@ describe('ImmisProxyServer security controls', () => {
     }
   });
 
+  it('rejects symlinked debug stream recording directories', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-immis-recording-'));
+    const targetDir = path.join(tmpDir, 'target');
+    const linkDir = path.join(tmpDir, 'blink-stream-recordings');
+    await fs.mkdir(targetDir);
+    await fs.symlink(targetDir, linkDir, 'dir');
+    const log = jest.fn();
+    const proxy = new ImmisProxyServer({
+      immisUrl: 'immis://stream.immedia-semi.com/session?client_id=1',
+      serial: 'TEST_SERIAL',
+      saveStreamPath: tmpDir,
+      log,
+    });
+
+    try {
+      await (proxy as unknown as { startStreamRecording: () => Promise<void> }).startStreamRecording();
+      expect((proxy as unknown as { streamFile: WriteStream | null }).streamFile).toBeNull();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Failed to start stream recording'));
+    } finally {
+      (proxy as unknown as { stopStreamRecording: () => void }).stopStreamRecording();
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it('redacts IMMIS auth identifiers from proxy debug logs', () => {
     const log = jest.fn();
     const proxy = new ImmisProxyServer({

--- a/__tests__/homebridge-ui/auth-state.test.ts
+++ b/__tests__/homebridge-ui/auth-state.test.ts
@@ -53,7 +53,24 @@ describe('homebridge UI persisted auth state loading', () => {
     expect(result.state).toBeNull();
     expect(result.message).toContain('saved token');
     expect(result.message).toContain('expired');
-    expect(logDebug).toHaveBeenCalledWith(result.message);
+    expect(result.message).not.toContain(tmpDir);
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining(primaryPath));
+  });
+
+  it('reports missing access tokens without exposing full auth paths', async () => {
+    await fs.writeFile(
+      primaryPath,
+      JSON.stringify({ ...state, accessToken: undefined }, null, 2),
+      'utf8',
+    );
+    await fs.chmod(primaryPath, 0o600);
+
+    const result = await loadPersistedAuthStateFromFiles([primaryPath], logDebug, now);
+
+    expect(result.state).toBeNull();
+    expect(result.message).toContain('does not contain an access token');
+    expect(result.message).not.toContain(tmpDir);
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining(primaryPath));
   });
 
   it('reports malformed persisted auth state instead of returning a generic logged-out status', async () => {
@@ -64,7 +81,8 @@ describe('homebridge UI persisted auth state loading', () => {
 
     expect(result.state).toBeNull();
     expect(result.message).toContain('failed to read');
-    expect(logDebug).toHaveBeenCalledWith(result.message);
+    expect(result.message).not.toContain(tmpDir);
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining(primaryPath));
   });
 
   it('reports invalid token expiry instead of restoring unusable persisted auth state', async () => {
@@ -79,7 +97,8 @@ describe('homebridge UI persisted auth state loading', () => {
 
     expect(result.state).toBeNull();
     expect(result.message).toContain('invalid expiry');
-    expect(logDebug).toHaveBeenCalledWith(result.message);
+    expect(result.message).not.toContain(tmpDir);
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining(primaryPath));
   });
 
   it('reports rejected auth state security errors instead of falling through silently', async () => {
@@ -93,6 +112,7 @@ describe('homebridge UI persisted auth state loading', () => {
     expect(result.state).toBeNull();
     expect(result.message).toContain('Persisted Blink authentication was ignored');
     expect(result.message).toContain('symlinked auth state file');
-    expect(logDebug).toHaveBeenCalledWith(result.message);
+    expect(result.message).not.toContain(tmpDir);
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining(primaryPath));
   });
 });

--- a/__tests__/homebridge-ui/auth-state.test.ts
+++ b/__tests__/homebridge-ui/auth-state.test.ts
@@ -1,0 +1,70 @@
+import { loadPersistedAuthStateFromFiles } from '../../src/homebridge-ui/auth-state';
+import { BlinkAuthState } from '../../src/types';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+describe('homebridge UI persisted auth state loading', () => {
+  let tmpDir: string;
+  let primaryPath: string;
+  let legacyPath: string;
+  const logDebug = jest.fn();
+  const now = (): number => new Date('2026-05-06T00:00:00.000Z').getTime();
+  const state: BlinkAuthState = {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    tokenAuth: 'token-auth',
+    tokenExpiry: '2026-05-06T01:00:00.000Z',
+    email: 'user@example.com',
+    accountId: 123,
+    tier: 'prod',
+  };
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'blink-ui-auth-'));
+    primaryPath = path.join(tmpDir, '.blink-auth.json');
+    legacyPath = path.join(tmpDir, 'blink-auth', 'auth-state.json');
+    logDebug.mockReset();
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('loads a valid primary persisted auth state', async () => {
+    await fs.writeFile(primaryPath, JSON.stringify(state, null, 2), 'utf8');
+    await fs.chmod(primaryPath, 0o600);
+
+    const result = await loadPersistedAuthStateFromFiles([primaryPath, legacyPath], logDebug, now);
+
+    expect(result).toEqual({ state });
+  });
+
+  it('skips expired auth state instead of restoring it', async () => {
+    await fs.writeFile(
+      primaryPath,
+      JSON.stringify({ ...state, tokenExpiry: '2026-05-05T23:59:00.000Z' }, null, 2),
+      'utf8',
+    );
+    await fs.chmod(primaryPath, 0o600);
+
+    const result = await loadPersistedAuthStateFromFiles([primaryPath], logDebug, now);
+
+    expect(result).toEqual({ state: null });
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining('expired token'));
+  });
+
+  it('reports rejected auth state security errors instead of falling through silently', async () => {
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, JSON.stringify(state, null, 2), 'utf8');
+    await fs.chmod(legacyPath, 0o600);
+    await fs.symlink(legacyPath, primaryPath);
+
+    const result = await loadPersistedAuthStateFromFiles([primaryPath, legacyPath], logDebug, now);
+
+    expect(result.state).toBeNull();
+    expect(result.message).toContain('Persisted Blink authentication was ignored');
+    expect(result.message).toContain('symlinked auth state file');
+    expect(logDebug).toHaveBeenCalledWith(result.message);
+  });
+});

--- a/__tests__/homebridge-ui/auth-state.test.ts
+++ b/__tests__/homebridge-ui/auth-state.test.ts
@@ -50,8 +50,21 @@ describe('homebridge UI persisted auth state loading', () => {
 
     const result = await loadPersistedAuthStateFromFiles([primaryPath], logDebug, now);
 
-    expect(result).toEqual({ state: null });
-    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining('expired token'));
+    expect(result.state).toBeNull();
+    expect(result.message).toContain('saved token');
+    expect(result.message).toContain('expired');
+    expect(logDebug).toHaveBeenCalledWith(result.message);
+  });
+
+  it('reports malformed persisted auth state instead of returning a generic logged-out status', async () => {
+    await fs.writeFile(primaryPath, '{not-json', 'utf8');
+    await fs.chmod(primaryPath, 0o600);
+
+    const result = await loadPersistedAuthStateFromFiles([primaryPath], logDebug, now);
+
+    expect(result.state).toBeNull();
+    expect(result.message).toContain('failed to read');
+    expect(logDebug).toHaveBeenCalledWith(result.message);
   });
 
   it('reports rejected auth state security errors instead of falling through silently', async () => {

--- a/__tests__/homebridge-ui/auth-state.test.ts
+++ b/__tests__/homebridge-ui/auth-state.test.ts
@@ -67,6 +67,21 @@ describe('homebridge UI persisted auth state loading', () => {
     expect(logDebug).toHaveBeenCalledWith(result.message);
   });
 
+  it('reports invalid token expiry instead of restoring unusable persisted auth state', async () => {
+    await fs.writeFile(
+      primaryPath,
+      JSON.stringify({ ...state, tokenExpiry: 'not-a-date' }, null, 2),
+      'utf8',
+    );
+    await fs.chmod(primaryPath, 0o600);
+
+    const result = await loadPersistedAuthStateFromFiles([primaryPath], logDebug, now);
+
+    expect(result.state).toBeNull();
+    expect(result.message).toContain('invalid expiry');
+    expect(logDebug).toHaveBeenCalledWith(result.message);
+  });
+
   it('reports rejected auth state security errors instead of falling through silently', async () => {
     await fs.mkdir(path.dirname(legacyPath), { recursive: true });
     await fs.writeFile(legacyPath, JSON.stringify(state, null, 2), 'utf8');

--- a/__tests__/platform.test.ts
+++ b/__tests__/platform.test.ts
@@ -108,4 +108,19 @@ describe('BlinkCamerasPlatform', () => {
     // Handler is stored in Map, not in context (to avoid circular JSON serialization)
     expect(cachedAccessory.context.device).toBe(network);
   });
+
+  it('forwards verifyImmisTls into the runtime streaming config', () => {
+    hapApi = createApi() as unknown as MockAPI;
+    const log = createLogger() as unknown as Logger;
+    const blinkApi = buildBlinkApi();
+    (BlinkApi as jest.Mock).mockImplementation(() => blinkApi);
+
+    const platform = new BlinkCamerasPlatform(
+      log,
+      { ...config, verifyImmisTls: false },
+      hapApi,
+    );
+
+    expect(platform.streamingConfig.verifyImmisTls).toBe(false);
+  });
 });

--- a/__tests__/schema-auth-ui.test.ts
+++ b/__tests__/schema-auth-ui.test.ts
@@ -186,6 +186,18 @@ describe('schema layout integrity', () => {
     expect(hits).toEqual([]);
   });
 
+  it('exposes IMMIS TLS verification as secure-by-default streaming config', () => {
+    const schema = readJson<SchemaDocument>('config.schema.json');
+    const properties = schema.schema?.properties ?? {};
+    const verifyImmisTls = properties.verifyImmisTls as Record<string, unknown>;
+
+    expect(verifyImmisTls.type).toBe('boolean');
+    expect(verifyImmisTls.default).toBe(true);
+
+    const layoutReferences = findLayoutKeyReferences(schema.layout ?? [], new Set(['verifyImmisTls']));
+    expect(layoutReferences).toEqual(['verifyImmisTls']);
+  });
+
   it('uses array-based device customization instead of object additionalProperties', () => {
     const schema = readJson<SchemaDocument>('config.schema.json');
     const properties = schema.schema?.properties ?? {};

--- a/config.schema.json
+++ b/config.schema.json
@@ -203,6 +203,12 @@
           { "title": "Linux VAAPI (advanced)", "enum": ["h264_vaapi"] }
         ]
       },
+      "verifyImmisTls": {
+        "title": "Verify IMMIS TLS",
+        "description": "Verify TLS certificates and hostnames for Blink IMMIS live streams. Keep enabled unless Blink support has confirmed your camera requires an insecure self-signed stream endpoint.",
+        "type": "boolean",
+        "default": true
+      },
       "excludeDevices": {
         "title": "Excluded Devices",
         "description": "List of device serial numbers, IDs, or names to exclude from HomeKit.",
@@ -315,6 +321,7 @@
         "audioBitrate",
         "videoBitrate",
         "videoEncoder",
+        "verifyImmisTls",
         "rtspTransport",
         "ffmpegDebug",
         "debugStreamPath"

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 86 tests.
+- `npm test -- --runInBand`: passed 13 suites, 87 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 88 tests.
+- `npm test -- --runInBand`: passed 13 suites, 90 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 87 tests.
+- `npm test -- --runInBand`: passed 13 suites, 88 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -264,7 +264,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 91 tests.
+- `npm test -- --runInBand`: passed 13 suites, 93 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 82 tests.
+- `npm test -- --runInBand`: passed 13 suites, 84 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -1,0 +1,229 @@
+# Auth, Streaming, and Security Audit - 2026-05-05
+
+## Scope
+
+Audit target: login/auth workflow, token persistence, HomeKit video transcoding
+and streaming, and security-sensitive logging/configuration.
+
+Primary paths:
+
+- `src/blink-api/auth.ts`
+- `src/blink-api/client.ts`
+- `src/blink-api/http.ts`
+- `src/blink-api/immis-proxy.ts`
+- `src/accessories/camera-source.ts`
+- `src/platform.ts`
+- `src/homebridge-ui/server.ts`
+- `config.schema.json`
+- `README.md`
+- `docs/debug_logging_spec.md`
+
+External contracts checked:
+
+- Homebridge/HAP-NodeJS `CameraStreamingDelegate` and `CameraControllerOptions`
+  docs for stream lifecycle and `cameraStreamCount`.
+- Node.js 20 TLS docs for SNI and certificate verification behavior.
+- FFmpeg SRTP protocol docs for `srtp_out_suite` and `srtp_out_params`.
+
+## Baseline Evidence
+
+- `npm test -- --runInBand`: passed 13 suites, 74 tests before remediation.
+- `npm run build`: passed before remediation.
+- `npm run lint`: 0 errors, 1 warning for unused `process` in
+  `src/accessories/camera-source.ts`.
+- `npm audit --omit=dev --json`: blocked by npm registry audit endpoint error.
+- Existing untracked files before work: `.vscode/`, `__tests__/.DS_Store`.
+
+## Findings
+
+### F1 - IMMIS TLS verification was disabled
+
+Severity: high
+
+Affected paths:
+
+- `src/blink-api/immis-proxy.ts`
+- `src/accessories/camera-source.ts`
+- `src/platform.ts`
+- `config.schema.json`
+
+Evidence: `tls.connect()` used `rejectUnauthorized: false` for upstream IMMIS
+connections. Node.js docs say SNI is not enabled by default for `tls.connect()`,
+so `servername` should be set with `host`; certificate authorization should stay
+enabled unless explicitly disabled.
+
+Root cause: the proxy treated Blink IMMIS endpoints as self-signed by default.
+
+Fix status: fixed
+
+Remediation:
+
+- Added `verifyImmisTls`, default `true`.
+- Passed `verifyTls` into `ImmisProxyServer`.
+- Set `rejectUnauthorized` from config, `servername` to the upstream host, and
+  `minVersion: 'TLSv1.2'`.
+- Documented the escape hatch for confirmed insecure/self-signed endpoints.
+
+Proof:
+
+- `npm test -- --runInBand __tests__/blink-api/immis-proxy.test.ts`
+- `npm test -- --runInBand __tests__/schema-auth-ui.test.ts`
+
+Residual risk: some real Blink IMMIS endpoints might still require disabled TLS
+verification. That is now an explicit user choice instead of silent default.
+
+### F2 - Streaming logs exposed liveview URLs and FFmpeg input secrets
+
+Severity: high
+
+Affected paths:
+
+- `src/accessories/camera-source.ts`
+- `docs/debug_logging_spec.md`
+
+Evidence: stream start logs printed the full `liveviewUrl`, and FFmpeg debug
+logs printed the full `-i` URL. Existing redaction only covered SRTP params.
+FFmpeg SRTP docs confirm `srtp_out_params` carries key/salt material, so keeping
+that redaction was also critical.
+
+Root cause: FFmpeg argument redaction only covered SRTP key arguments and did
+not classify Blink stream URLs as sensitive.
+
+Fix status: fixed
+
+Remediation:
+
+- Added stream URL redaction for `immis://`, `rtsp://`, and `rtsps://`.
+- Kept raw URL only in the actual FFmpeg spawn args.
+- Extended debug logging spec to require liveview URL and SRTP redaction.
+
+Proof:
+
+- `npm test -- --runInBand __tests__/accessories.test.ts`
+
+Residual risk: local `tcp://` proxy URLs remain visible because they are local
+loopback endpoints without upstream auth material.
+
+### F3 - Debug stream recording filenames exposed camera serials
+
+Severity: medium
+
+Affected paths:
+
+- `src/blink-api/immis-proxy.ts`
+- `README.md`
+- `docs/debug_logging_spec.md`
+
+Evidence: `debugStreamPath` recordings were named
+`blink-stream-<serial>-<timestamp>.ts`. The recordings contain raw MPEG-TS video
+and the filename exposed the physical camera serial.
+
+Root cause: serial was reused as a human-friendly debug identifier.
+
+Fix status: fixed
+
+Remediation:
+
+- Replaced raw serial filenames with a 16-character SHA-256-derived identifier.
+- Created debug recording files with mode `0600`.
+- Created new recording directories with mode `0700` when possible.
+- Documented recording privacy behavior.
+
+Proof:
+
+- `npm test -- --runInBand __tests__/blink-api/immis-proxy.test.ts`
+
+Residual risk: raw video capture remains sensitive by nature. Users still need
+to choose a private `debugStreamPath`.
+
+### F4 - Existing persisted auth files were not hardened on load
+
+Severity: medium
+
+Affected paths:
+
+- `src/blink-api/auth.ts`
+
+Evidence: new token files were saved with `0600`, but an existing primary auth
+file with broader mode could be loaded without being tightened.
+
+Root cause: permission hardening was only on save/migration, not on primary
+load.
+
+Fix status: fixed
+
+Remediation:
+
+- Added best-effort `chmod(0600)` after reading persisted auth state.
+
+Proof:
+
+- `npm test -- --runInBand __tests__/blink-api/auth.test.ts`
+
+Residual risk: non-POSIX filesystems may not enforce Unix modes; hardening is
+best-effort there.
+
+### F5 - Stream concurrency relied only on Homebridge controller limits
+
+Severity: medium
+
+Affected paths:
+
+- `src/accessories/camera-source.ts`
+
+Evidence: `cameraStreamCount` was configured, but `startStream()` did not check
+`ongoingSessions.size` before requesting a new Blink live view. The Homebridge
+docs identify `CameraStreamingDelegate` as the handler of stream requests, so
+the delegate should also guard resource limits.
+
+Root cause: concurrency limit was advertised but not enforced at the delegate
+boundary.
+
+Fix status: fixed
+
+Remediation:
+
+- Reject new stream starts when `ongoingSessions.size >= maxStreams`.
+- Release pending RTP/RTCP ports before returning an error.
+- Avoid requesting Blink live view when the limit is already reached.
+
+Proof:
+
+- `npm test -- --runInBand __tests__/accessories.test.ts`
+
+Residual risk: prepared-but-never-started sessions can still hold ports until
+HomeKit sends stop or process restarts. No leak was reproduced in baseline.
+
+### F6 - Dependency audit initially could not complete
+
+Severity: medium
+
+Affected paths:
+
+- `package-lock.json`
+- npm registry audit endpoint
+
+Evidence: `npm audit --omit=dev --json` initially failed with an npm registry
+audit endpoint error before remediation.
+
+Fix status: not reproducible
+
+Resolution evidence: a later rerun completed successfully and reported zero
+production vulnerabilities.
+
+## Verification Ledger
+
+Targeted commands after remediation:
+
+- `npm test -- --runInBand __tests__/blink-api/auth.test.ts`
+- `npm test -- --runInBand __tests__/blink-api/immis-proxy.test.ts`
+- `npm test -- --runInBand __tests__/accessories.test.ts`
+- `npm test -- --runInBand __tests__/schema-auth-ui.test.ts`
+- `npx tsc --noEmit`
+
+Final full gate:
+
+- `npm test -- --runInBand`: passed 13 suites, 81 tests.
+- `npm run build`: passed.
+- `npm run lint`: passed with no warnings.
+- `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 81 tests.
+- `npm test -- --runInBand`: passed 13 suites, 82 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -131,6 +131,9 @@ Remediation:
 - Created debug recording files with mode `0600`.
 - Created new recording directories with mode `0700` when possible.
 - Documented recording privacy behavior.
+- Documented that recordings created by older versions under
+  `<debugStreamPath>/blink-stream-*.ts` are not moved or re-permissioned
+  automatically.
 
 Proof:
 
@@ -146,9 +149,12 @@ Severity: medium
 Affected paths:
 
 - `src/blink-api/auth.ts`
+- `src/homebridge-ui/server.ts`
 
 Evidence: new token files were saved with `0600`, but an existing primary auth
-file with broader mode could be loaded without being tightened.
+file with broader mode could be loaded without being tightened. The UI status
+path also read persisted auth state directly from disk without sharing the
+same hardening path.
 
 Root cause: permission hardening was only on save/migration, not on primary
 load.
@@ -158,6 +164,8 @@ Fix status: fixed
 Remediation:
 
 - Added best-effort `chmod(0600)` after reading persisted auth state.
+- Rejected symlinked auth state files before reading or hardening them.
+- Reused the hardened auth-state reader from the Homebridge UI status path.
 
 Proof:
 
@@ -256,7 +264,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 90 tests.
+- `npm test -- --runInBand`: passed 13 suites, 91 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 85 tests.
+- `npm test -- --runInBand`: passed 13 suites, 86 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -32,6 +32,9 @@ External contracts checked:
 - `npm run lint`: 0 errors, 1 warning for unused `process` in
   `src/accessories/camera-source.ts`.
 - `npm audit --omit=dev --json`: blocked by npm registry audit endpoint error.
+- After rebasing on the updated remote, `npm audit --json` reported dev-only
+  transitive vulnerabilities in `handlebars`, `flatted`, `minimatch`,
+  `picomatch`, `brace-expansion`, and `ajv`.
 - Existing untracked files before work: `.vscode/`, `__tests__/.DS_Store`.
 
 ## Findings
@@ -211,6 +214,36 @@ Fix status: not reproducible
 Resolution evidence: a later rerun completed successfully and reported zero
 production vulnerabilities.
 
+### F7 - Dev dependency audit reported vulnerable transitive packages
+
+Severity: medium
+
+Affected paths:
+
+- `package-lock.json`
+
+Evidence: after rebasing on the updated remote, `npm audit --json` reported
+six vulnerable transitive dev packages, including one critical advisory through
+`handlebars`.
+
+Root cause: lockfile pinned older vulnerable transitive versions allowed by
+current dependency ranges.
+
+Fix status: fixed
+
+Remediation:
+
+- Ran `npm audit fix` without `--force`.
+- Updated only `package-lock.json`.
+- Removed the reported dev dependency vulnerabilities.
+
+Proof:
+
+- `npm audit --json`: passed with 0 total vulnerabilities.
+
+Residual risk: this audit fix covers npm advisories visible to the registry at
+the time of the run. It does not replace Dependabot monitoring.
+
 ## Verification Ledger
 
 Targeted commands after remediation:
@@ -227,3 +260,5 @@ Final full gate:
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.
+- `npm audit --json`: passed with 0 total vulnerabilities after lockfile
+  remediation.

--- a/docs/audits/2026-05-05-auth-streaming-security-audit.md
+++ b/docs/audits/2026-05-05-auth-streaming-security-audit.md
@@ -256,7 +256,7 @@ Targeted commands after remediation:
 
 Final full gate:
 
-- `npm test -- --runInBand`: passed 13 suites, 84 tests.
+- `npm test -- --runInBand`: passed 13 suites, 85 tests.
 - `npm run build`: passed.
 - `npm run lint`: passed with no warnings.
 - `npm audit --omit=dev --json`: passed with 0 production vulnerabilities.

--- a/docs/debug_logging_spec.md
+++ b/docs/debug_logging_spec.md
@@ -51,7 +51,7 @@ Recommended redaction pattern: show first 3–4 chars and last 3–4 chars, othe
 
 ## Streaming Diagnostics
 
-- `ffmpegDebug` should toggle FFmpeg loglevel (`debug` vs `error`).
+- `ffmpegDebug` should toggle FFmpeg loglevel (`debug` vs `info`).
 - Streaming logs must not include raw stream tokens, liveview URLs, SRTP keys, or device serials unless redacted.
 - Debug stream recordings must avoid raw camera serials in filenames and use owner-only file permissions.
 

--- a/docs/debug_logging_spec.md
+++ b/docs/debug_logging_spec.md
@@ -52,7 +52,8 @@ Recommended redaction pattern: show first 3–4 chars and last 3–4 chars, othe
 ## Streaming Diagnostics
 
 - `ffmpegDebug` should toggle FFmpeg loglevel (`debug` vs `error`).
-- Streaming logs must not include raw stream tokens or device serials unless redacted.
+- Streaming logs must not include raw stream tokens, liveview URLs, SRTP keys, or device serials unless redacted.
+- Debug stream recordings must avoid raw camera serials in filenames and use owner-only file permissions.
 
 ## EventStream Diagnostics (If Implemented)
 

--- a/docs/future/live-streaming.md
+++ b/docs/future/live-streaming.md
@@ -7,9 +7,10 @@
 
 ## Overview
 
-This document outlines the technical requirements for adding live video streaming to @sealad886/homebridge-blink-cameras-new-api.
+This document outlined the original technical requirements for adding live
+video streaming to @sealad886/homebridge-blink-cameras-new-api.
 
-## Current State
+## Implemented State
 
 The plugin currently supports:
 
@@ -60,7 +61,8 @@ interface CameraStreamingDelegate {
 }
 ```
 
-Currently only `handleSnapshotRequest` is implemented.
+`handleSnapshotRequest`, `prepareStream`, and `handleStreamRequest` are now
+implemented in `src/accessories/camera-source.ts`.
 
 ### 4. Stream Lifecycle
 

--- a/docs/future/live-streaming.md
+++ b/docs/future/live-streaming.md
@@ -1,5 +1,10 @@
 # Live Streaming Implementation
 
+> Status: historical design note. Live streaming is now implemented in
+> `src/accessories/camera-source.ts` with IMMIS proxy support in
+> `src/blink-api/immis-proxy.ts`. Use the README live-streaming section for
+> current user-facing configuration.
+
 ## Overview
 
 This document outlines the technical requirements for adding live video streaming to @sealad886/homebridge-blink-cameras-new-api.
@@ -10,8 +15,11 @@ The plugin currently supports:
 
 - Static snapshots via the Blink thumbnail API
 - Motion detection via polling
-
-Live streaming is **not** implemented.
+- HomeKit live streaming through `CameraStreamingDelegate`
+- FFmpeg transcoding from Blink RTSPS/IMMIS input to HomeKit SRTP output
+- Optional hardware H.264 encoder probing with `libx264` fallback
+- Single-stream default enforcement via `maxStreams`
+- Secure-by-default IMMIS TLS verification and redacted FFmpeg diagnostics
 
 ## Technical Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -640,9 +640,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -651,9 +651,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -714,9 +714,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -735,9 +735,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2191,9 +2191,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2462,9 +2462,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3258,9 +3258,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3292,9 +3292,9 @@
             }
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -3569,9 +3569,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -3832,9 +3832,9 @@
             "license": "ISC"
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5039,9 +5039,9 @@
             }
         },
         "node_modules/jest-util/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5392,13 +5392,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5553,9 +5553,9 @@
             }
         },
         "node_modules/nodemon/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5574,9 +5574,9 @@
             }
         },
         "node_modules/nodemon/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5898,9 +5898,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6731,9 +6731,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6764,9 +6764,9 @@
             }
         },
         "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6826,9 +6826,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/src/accessories/camera-source.ts
+++ b/src/accessories/camera-source.ts
@@ -551,7 +551,10 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
       return;
     }
 
-    if (this.ongoingSessions.size >= this.streamingConfig.maxStreams) {
+    const activeStreamCount = Array.from(this.ongoingSessions.values())
+      .filter((session) => !session.stopped)
+      .length;
+    if (activeStreamCount >= this.streamingConfig.maxStreams) {
       this.log(
         `Stream start rejected for session ${sessionId}: maxStreams=${this.streamingConfig.maxStreams} already reached`,
       );

--- a/src/accessories/camera-source.ts
+++ b/src/accessories/camera-source.ts
@@ -56,6 +56,7 @@ export interface BlinkCameraStreamingConfig {
     maxBitrate?: number;
     encoder: VideoEncoderPreference;
   };
+  verifyImmisTls: boolean;
   /** Path to save debug stream recordings (MPEG-TS files) */
   debugStreamPath?: string;
   /** Snapshot cache TTL in seconds (0 = always request fresh, default 60) */
@@ -89,6 +90,7 @@ const DEFAULT_STREAMING_CONFIG: BlinkCameraStreamingConfig = {
   video: {
     encoder: 'auto',
   },
+  verifyImmisTls: true,
   snapshotCacheTTL: 60,
   persistSnapshotCache: false,
 };
@@ -108,6 +110,7 @@ export const resolveStreamingConfig = (
     rtspTransport: config?.rtspTransport ?? DEFAULT_STREAMING_CONFIG.rtspTransport,
     maxStreams: Math.max(1, config?.maxStreams ?? DEFAULT_STREAMING_CONFIG.maxStreams),
     debugStreamPath: config?.debugStreamPath,
+    verifyImmisTls: config?.verifyImmisTls ?? DEFAULT_STREAMING_CONFIG.verifyImmisTls,
     snapshotCacheTTL: config?.snapshotCacheTTL ?? DEFAULT_STREAMING_CONFIG.snapshotCacheTTL,
     persistSnapshotCache: config?.persistSnapshotCache ?? DEFAULT_STREAMING_CONFIG.persistSnapshotCache,
     audio: {
@@ -177,9 +180,23 @@ const redactFfmpegArgs = (args: string[]): string[] => {
       if (i + 1 < redacted.length) {
         redacted[i + 1] = '<redacted>';
       }
+    } else {
+      redacted[i] = redactStreamUrl(redacted[i]);
     }
   }
   return redacted;
+};
+
+const redactStreamUrl = (value: string): string => {
+  try {
+    const parsed = new URL(value);
+    if (!['immis:', 'rtsp:', 'rtsps:'].includes(parsed.protocol)) {
+      return value;
+    }
+    return `${parsed.protocol}//${parsed.host}/<redacted>`;
+  } catch {
+    return value;
+  }
 };
 
 const allocatePort = async (): Promise<number> => {
@@ -526,6 +543,19 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
       return;
     }
 
+    if (this.ongoingSessions.size >= this.streamingConfig.maxStreams) {
+      this.log(
+        `Stream start rejected for session ${sessionId}: maxStreams=${this.streamingConfig.maxStreams} already reached`,
+      );
+      releasePort(pending.localVideoPort);
+      releasePort(pending.localVideoRtcpPort);
+      releasePort(pending.localAudioPort);
+      releasePort(pending.localAudioRtcpPort);
+      this.pendingSessions.delete(sessionId);
+      callback(new Error(`Maximum live stream count (${this.streamingConfig.maxStreams}) reached`));
+      return;
+    }
+
     const active: ActiveStreamSession = {
       ...pending,
       keepAliveTimer: null,
@@ -565,6 +595,7 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
           log: (msg) => this.log(msg),
           debug: this.streamingConfig.ffmpegDebug,
           saveStreamPath: this.streamingConfig.debugStreamPath,
+          verifyTls: this.streamingConfig.verifyImmisTls,
           waitForReady: readyPromise,
         });
 
@@ -947,7 +978,7 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
     const ffmpegArgs = this.buildFfmpegArgs(liveviewUrl, request, active, videoEncoder);
     active.selectedVideoEncoder = videoEncoder;
 
-    this.log(`Starting stream ${sessionId} via FFmpeg using ${videoEncoder} with URL: ${liveviewUrl}`);
+    this.log(`Starting stream ${sessionId} via FFmpeg using ${videoEncoder} with URL: ${redactStreamUrl(liveviewUrl)}`);
     if (this.streamingConfig.ffmpegDebug) {
       const safeArgs = redactFfmpegArgs(ffmpegArgs);
       this.log(`FFmpeg args: ${safeArgs.join(' ')}`);

--- a/src/accessories/camera-source.ts
+++ b/src/accessories/camera-source.ts
@@ -1079,7 +1079,7 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
     }
 
     active.ffmpegStderrBuffer = `${active.ffmpegStderrBuffer ?? ''}${data.toString('utf8')}`;
-    const lines = active.ffmpegStderrBuffer.split(/\r?\n/);
+    const lines = active.ffmpegStderrBuffer.split(/\r\n|\n|\r/);
     active.ffmpegStderrBuffer = lines.pop() ?? '';
 
     for (const line of lines) {

--- a/src/accessories/camera-source.ts
+++ b/src/accessories/camera-source.ts
@@ -74,6 +74,7 @@ export type BlinkCameraStreamingConfigInput = Omit<
 };
 
 const SOFTWARE_VIDEO_ENCODER: VideoEncoderPreference = 'libx264';
+const MAX_FFMPEG_STDERR_BUFFER_CHARS = 64 * 1024;
 
 const DEFAULT_STREAMING_CONFIG: BlinkCameraStreamingConfig = {
   enabled: true,
@@ -156,6 +157,7 @@ interface ActiveStreamSession extends PendingStreamSession {
   fallbackVideoEncoderTried?: boolean;
   readyNotified?: boolean;
   ffmpegStderrBuffer?: string;
+  ffmpegStderrBufferTruncated?: boolean;
 }
 
 const usedPorts = new Set<number>();
@@ -1081,17 +1083,61 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
       return;
     }
 
-    active.ffmpegStderrBuffer = `${active.ffmpegStderrBuffer ?? ''}${data.toString('utf8')}`;
-    const lines = active.ffmpegStderrBuffer.split(/\r\n|\n|\r/);
-    active.ffmpegStderrBuffer = lines.pop() ?? '';
+    const chunk = data.toString('utf8');
+    let lineStart = 0;
 
-    for (const line of lines) {
-      this.logRedactedFfmpegLine(sessionId, line);
+    for (let index = 0; index < chunk.length; index++) {
+      const char = chunk.charCodeAt(index);
+      if (char !== 10 && char !== 13) {
+        continue;
+      }
+
+      this.appendFfmpegStderrSegment(active, chunk.slice(lineStart, index));
+      this.flushFfmpegStderrLine(sessionId, active);
+
+      if (char === 13 && chunk.charCodeAt(index + 1) === 10) {
+        index++;
+      }
+      lineStart = index + 1;
     }
+
+    this.appendFfmpegStderrSegment(active, chunk.slice(lineStart));
   }
 
   private flushFfmpegStderr(sessionId: string, active: ActiveStreamSession): void {
-    if (!this.streamingConfig.ffmpegDebug || !active.ffmpegStderrBuffer) {
+    if (!this.streamingConfig.ffmpegDebug) {
+      return;
+    }
+
+    this.flushFfmpegStderrLine(sessionId, active);
+  }
+
+  private appendFfmpegStderrSegment(active: ActiveStreamSession, segment: string): void {
+    if (!segment || active.ffmpegStderrBufferTruncated) {
+      return;
+    }
+
+    const currentBuffer = active.ffmpegStderrBuffer ?? '';
+    if (currentBuffer.length + segment.length <= MAX_FFMPEG_STDERR_BUFFER_CHARS) {
+      active.ffmpegStderrBuffer = `${currentBuffer}${segment}`;
+      return;
+    }
+
+    active.ffmpegStderrBuffer = '';
+    active.ffmpegStderrBufferTruncated = true;
+  }
+
+  private flushFfmpegStderrLine(sessionId: string, active: ActiveStreamSession): void {
+    if (active.ffmpegStderrBufferTruncated) {
+      this.log(
+        `FFmpeg(${sessionId}): <stderr line omitted because it exceeded ${MAX_FFMPEG_STDERR_BUFFER_CHARS} characters>`,
+      );
+      active.ffmpegStderrBuffer = '';
+      active.ffmpegStderrBufferTruncated = false;
+      return;
+    }
+
+    if (!active.ffmpegStderrBuffer) {
       return;
     }
 

--- a/src/accessories/camera-source.ts
+++ b/src/accessories/camera-source.ts
@@ -155,6 +155,7 @@ interface ActiveStreamSession extends PendingStreamSession {
   selectedVideoEncoder?: VideoEncoderPreference;
   fallbackVideoEncoderTried?: boolean;
   readyNotified?: boolean;
+  ffmpegStderrBuffer?: string;
 }
 
 const usedPorts = new Set<number>();
@@ -1019,15 +1020,14 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
     });
 
     ffmpeg.stderr.on('data', (data) => {
-      if (this.streamingConfig.ffmpegDebug) {
-        this.log(`FFmpeg(${sessionId}): ${redactFfmpegOutput(data.toString('utf8').trim())}`);
-      }
+      this.handleFfmpegStderr(sessionId, active, data);
     });
 
     ffmpeg.on('error', (error) => {
       if (active.ffmpeg !== ffmpeg) {
         return;
       }
+      this.flushFfmpegStderr(sessionId, active);
 
       this.log(`FFmpeg failed to start for session ${sessionId} using ${videoEncoder}: ${error.message}`);
 
@@ -1048,6 +1048,7 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
       if (active.ffmpeg !== ffmpeg) {
         return;
       }
+      this.flushFfmpegStderr(sessionId, active);
 
       if (
         (code !== 0 || signal) &&
@@ -1070,6 +1071,36 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
       }
       void this.stopStream(sessionId);
     });
+  }
+
+  private handleFfmpegStderr(sessionId: string, active: ActiveStreamSession, data: Buffer): void {
+    if (!this.streamingConfig.ffmpegDebug) {
+      return;
+    }
+
+    active.ffmpegStderrBuffer = `${active.ffmpegStderrBuffer ?? ''}${data.toString('utf8')}`;
+    const lines = active.ffmpegStderrBuffer.split(/\r?\n/);
+    active.ffmpegStderrBuffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      this.logRedactedFfmpegLine(sessionId, line);
+    }
+  }
+
+  private flushFfmpegStderr(sessionId: string, active: ActiveStreamSession): void {
+    if (!this.streamingConfig.ffmpegDebug || !active.ffmpegStderrBuffer) {
+      return;
+    }
+
+    this.logRedactedFfmpegLine(sessionId, active.ffmpegStderrBuffer);
+    active.ffmpegStderrBuffer = '';
+  }
+
+  private logRedactedFfmpegLine(sessionId: string, line: string): void {
+    const trimmed = line.trim();
+    if (trimmed) {
+      this.log(`FFmpeg(${sessionId}): ${redactFfmpegOutput(trimmed)}`);
+    }
   }
 
   private resolveVideoEncoder(): VideoEncoderPreference {

--- a/src/accessories/camera-source.ts
+++ b/src/accessories/camera-source.ts
@@ -187,6 +187,13 @@ const redactFfmpegArgs = (args: string[]): string[] => {
   return redacted;
 };
 
+const redactFfmpegOutput = (value: string): string => {
+  return value
+    .replace(/\b(?:immis|rtsps?):\/\/[^\s'"]+/gi, (url) => redactStreamUrl(url))
+    .replace(/(-srtp_(?:out|in)_params\s+)(\S+)/gi, '$1<redacted>')
+    .replace(/(\bsrtp_(?:out|in)_params[=:])(\S+)/gi, '$1<redacted>');
+};
+
 const redactStreamUrl = (value: string): string => {
   try {
     const parsed = new URL(value);
@@ -599,6 +606,19 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
           waitForReady: readyPromise,
         });
 
+        immisProxy.on('error', (error) => {
+          if (active.immisProxy !== immisProxy || active.stopped) {
+            return;
+          }
+
+          this.log(`IMMIS proxy error for session ${sessionId}: ${error.message}`);
+          if (!active.readyNotified) {
+            active.readyNotified = true;
+            callback(error);
+          }
+          void this.stopStream(sessionId);
+        });
+
         active.immisProxy = immisProxy;
         ffmpegInputUrl = await immisProxy.start();
         this.log(`IMMIS proxy ready at ${ffmpegInputUrl}`);
@@ -1000,7 +1020,7 @@ export class BlinkCameraSource implements CameraStreamingDelegate {
 
     ffmpeg.stderr.on('data', (data) => {
       if (this.streamingConfig.ffmpegDebug) {
-        this.log(`FFmpeg(${sessionId}): ${data.toString('utf8').trim()}`);
+        this.log(`FFmpeg(${sessionId}): ${redactFfmpegOutput(data.toString('utf8').trim())}`);
       }
     });
 

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -39,7 +39,9 @@ import {
 } from './urls';
 import { generatePKCEPair, generateOAuthState } from './oauth-pkce';
 import { constants as fsConstants, promises as fs } from 'node:fs';
+import type { Stats } from 'node:fs';
 import * as path from 'node:path';
+import process from 'node:process';
 import { URL } from 'node:url';
 import { randomUUID } from 'node:crypto';
 
@@ -48,12 +50,16 @@ type FetchResponse = Awaited<ReturnType<typeof fetch>>;
 const TOKEN_EXPIRY_BUFFER_MS = 60 * 60 * 1000; // 1 hour
 const REFRESH_MAX_RETRIES = 2;
 const REFRESH_RETRY_DELAYS_MS = [2000, 5000];
+const OWNER_ONLY_AUTH_FILE_MODE = 0o600;
+const SHARED_AUTH_FILE_MODE_MASK = 0o077;
+const POSIX_MODE_MASK = 0o777;
 
 const isNodeError = (error: unknown, code: string): boolean => {
   return (error as { code?: string }).code === code;
 };
 
 type AuthStateFileHandle = Awaited<ReturnType<typeof fs.open>>;
+type AuthStateFileModeTarget = string | Pick<AuthStateFileHandle, 'chmod' | 'stat'>;
 
 const noFollowFlag = fsConstants.O_NOFOLLOW ?? 0;
 
@@ -64,17 +70,71 @@ const isSameFile = (
   return pathStats.dev === handleStats.dev && pathStats.ino === handleStats.ino;
 };
 
+const formatFileMode = (mode: number): string => {
+  return `0${(mode & POSIX_MODE_MASK).toString(8)}`;
+};
+
+const hasSharedAuthFilePermissions = (mode: number): boolean => {
+  return (mode & SHARED_AUTH_FILE_MODE_MASK) !== 0;
+};
+
+export class AuthStateFileSecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthStateFileSecurityError';
+  }
+}
+
 export async function hardenAuthStateFileMode(
-  target: string | Pick<AuthStateFileHandle, 'chmod'>,
+  target: AuthStateFileModeTarget,
+  filePath = typeof target === 'string' ? target : 'auth state file',
 ): Promise<void> {
+  const getStats = async (): Promise<Stats> => {
+    if (typeof target === 'string') {
+      return fs.lstat(target);
+    }
+    return target.stat();
+  };
+
+  const originalStats = await getStats();
+  if (originalStats.isSymbolicLink()) {
+    throw new AuthStateFileSecurityError(`Refusing to harden symlinked auth state file: ${filePath}`);
+  }
+  if (!originalStats.isFile()) {
+    throw new AuthStateFileSecurityError(`Auth state path is not a regular file: ${filePath}`);
+  }
+
+  const originalMode = originalStats.mode;
+  if (!hasSharedAuthFilePermissions(originalMode)) {
+    return;
+  }
+
   try {
     if (typeof target === 'string') {
-      await fs.chmod(target, 0o600);
+      await fs.chmod(target, OWNER_ONLY_AUTH_FILE_MODE);
     } else {
-      await target.chmod(0o600);
+      await target.chmod(OWNER_ONLY_AUTH_FILE_MODE);
     }
   } catch {
-    // Best-effort only: some filesystems may not support POSIX modes.
+    if (process.platform !== 'win32') {
+      throw new AuthStateFileSecurityError(
+        `Persisted auth state file permissions are ${formatFileMode(originalMode)} ` +
+        `and could not be tightened to ${formatFileMode(OWNER_ONLY_AUTH_FILE_MODE)}: ${filePath}`,
+      );
+    }
+    return;
+  }
+
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  const hardenedMode = (await getStats()).mode;
+  if (hasSharedAuthFilePermissions(hardenedMode)) {
+    throw new AuthStateFileSecurityError(
+      `Persisted auth state file permissions remain ${formatFileMode(hardenedMode)} ` +
+      `after tightening to ${formatFileMode(OWNER_ONLY_AUTH_FILE_MODE)}: ${filePath}`,
+    );
   }
 }
 
@@ -87,21 +147,21 @@ export async function readPersistedAuthStateFile(filePath: string): Promise<Blin
       handle.stat(),
     ]);
     if (pathStats.isSymbolicLink()) {
-      throw new Error(`Refusing to use symlinked auth state file: ${filePath}`);
+      throw new AuthStateFileSecurityError(`Refusing to use symlinked auth state file: ${filePath}`);
     }
     if (!pathStats.isFile() || !handleStats.isFile()) {
-      throw new Error(`Auth state path is not a regular file: ${filePath}`);
+      throw new AuthStateFileSecurityError(`Auth state path is not a regular file: ${filePath}`);
     }
     if (!isSameFile(pathStats, handleStats)) {
-      throw new Error(`Auth state file changed while opening: ${filePath}`);
+      throw new AuthStateFileSecurityError(`Auth state file changed while opening: ${filePath}`);
     }
 
+    await hardenAuthStateFileMode(handle, filePath);
     const contents = await handle.readFile({ encoding: 'utf8' });
-    await hardenAuthStateFileMode(handle);
     return (JSON.parse(contents) as BlinkAuthState) ?? null;
   } catch (error) {
     if (isNodeError(error, 'ELOOP')) {
-      throw new Error(`Refusing to use symlinked auth state file: ${filePath}`);
+      throw new AuthStateFileSecurityError(`Refusing to use symlinked auth state file: ${filePath}`);
     }
     throw error;
   } finally {

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -49,6 +49,45 @@ const TOKEN_EXPIRY_BUFFER_MS = 60 * 60 * 1000; // 1 hour
 const REFRESH_MAX_RETRIES = 2;
 const REFRESH_RETRY_DELAYS_MS = [2000, 5000];
 
+const isNodeError = (error: unknown, code: string): boolean => {
+  return (error as { code?: string }).code === code;
+};
+
+const assertSafeAuthStateFilePath = async (
+  filePath: string,
+  allowMissing = false,
+): Promise<void> => {
+  try {
+    const stats = await fs.lstat(filePath);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked auth state file: ${filePath}`);
+    }
+    if (!stats.isFile()) {
+      throw new Error(`Auth state path is not a regular file: ${filePath}`);
+    }
+  } catch (error) {
+    if (allowMissing && isNodeError(error, 'ENOENT')) {
+      return;
+    }
+    throw error;
+  }
+};
+
+export async function hardenAuthStateFileMode(filePath: string): Promise<void> {
+  try {
+    await fs.chmod(filePath, 0o600);
+  } catch {
+    // Best-effort only: some filesystems may not support POSIX modes.
+  }
+}
+
+export async function readPersistedAuthStateFile(filePath: string): Promise<BlinkAuthState | null> {
+  await assertSafeAuthStateFilePath(filePath);
+  const contents = await fs.readFile(filePath, 'utf8');
+  await hardenAuthStateFileMode(filePath);
+  return (JSON.parse(contents) as BlinkAuthState) ?? null;
+}
+
 class FileAuthStorage implements BlinkAuthStorage {
   /** Legacy directory-based path for migration (e.g. .../blink-auth/auth-state.json) */
   private readonly legacyPath: string | null;
@@ -77,6 +116,7 @@ class FileAuthStorage implements BlinkAuthStorage {
   async save(state: BlinkAuthState): Promise<void> {
     const payload = JSON.stringify(state, null, 2);
     await fs.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    await assertSafeAuthStateFilePath(this.filePath, true);
     await fs.writeFile(this.filePath, payload, { encoding: 'utf8', mode: 0o600 });
     await fs.chmod(this.filePath, 0o600);
   }
@@ -90,20 +130,10 @@ class FileAuthStorage implements BlinkAuthStorage {
 
   private async readJsonFile(filePath: string): Promise<BlinkAuthState | null> {
     try {
-      const contents = await fs.readFile(filePath, 'utf8');
-      await this.hardenFileMode(filePath);
-      return (JSON.parse(contents) as BlinkAuthState) ?? null;
+      return await readPersistedAuthStateFile(filePath);
     } catch (error) {
-      if ((error as { code?: string }).code === 'ENOENT') return null;
+      if (isNodeError(error, 'ENOENT')) return null;
       throw error;
-    }
-  }
-
-  private async hardenFileMode(filePath: string): Promise<void> {
-    try {
-      await fs.chmod(filePath, 0o600);
-    } catch {
-      // Best-effort only: some filesystems may not support POSIX modes.
     }
   }
 

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -91,10 +91,19 @@ class FileAuthStorage implements BlinkAuthStorage {
   private async readJsonFile(filePath: string): Promise<BlinkAuthState | null> {
     try {
       const contents = await fs.readFile(filePath, 'utf8');
+      await this.hardenFileMode(filePath);
       return (JSON.parse(contents) as BlinkAuthState) ?? null;
     } catch (error) {
       if ((error as { code?: string }).code === 'ENOENT') return null;
       throw error;
+    }
+  }
+
+  private async hardenFileMode(filePath: string): Promise<void> {
+    try {
+      await fs.chmod(filePath, 0o600);
+    } catch {
+      // Best-effort only: some filesystems may not support POSIX modes.
     }
   }
 

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -38,7 +38,7 @@ import {
   getOAuth2FAVerifyUrl,
 } from './urls';
 import { generatePKCEPair, generateOAuthState } from './oauth-pkce';
-import { promises as fs } from 'node:fs';
+import { constants as fsConstants, promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { URL } from 'node:url';
 import { randomUUID } from 'node:crypto';
@@ -53,39 +53,60 @@ const isNodeError = (error: unknown, code: string): boolean => {
   return (error as { code?: string }).code === code;
 };
 
-const assertSafeAuthStateFilePath = async (
-  filePath: string,
-  allowMissing = false,
-): Promise<void> => {
-  try {
-    const stats = await fs.lstat(filePath);
-    if (stats.isSymbolicLink()) {
-      throw new Error(`Refusing to use symlinked auth state file: ${filePath}`);
-    }
-    if (!stats.isFile()) {
-      throw new Error(`Auth state path is not a regular file: ${filePath}`);
-    }
-  } catch (error) {
-    if (allowMissing && isNodeError(error, 'ENOENT')) {
-      return;
-    }
-    throw error;
-  }
+type AuthStateFileHandle = Awaited<ReturnType<typeof fs.open>>;
+
+const noFollowFlag = fsConstants.O_NOFOLLOW ?? 0;
+
+const isSameFile = (
+  pathStats: Awaited<ReturnType<typeof fs.lstat>>,
+  handleStats: Awaited<ReturnType<AuthStateFileHandle['stat']>>,
+): boolean => {
+  return pathStats.dev === handleStats.dev && pathStats.ino === handleStats.ino;
 };
 
-export async function hardenAuthStateFileMode(filePath: string): Promise<void> {
+export async function hardenAuthStateFileMode(
+  target: string | Pick<AuthStateFileHandle, 'chmod'>,
+): Promise<void> {
   try {
-    await fs.chmod(filePath, 0o600);
+    if (typeof target === 'string') {
+      await fs.chmod(target, 0o600);
+    } else {
+      await target.chmod(0o600);
+    }
   } catch {
     // Best-effort only: some filesystems may not support POSIX modes.
   }
 }
 
 export async function readPersistedAuthStateFile(filePath: string): Promise<BlinkAuthState | null> {
-  await assertSafeAuthStateFilePath(filePath);
-  const contents = await fs.readFile(filePath, 'utf8');
-  await hardenAuthStateFileMode(filePath);
-  return (JSON.parse(contents) as BlinkAuthState) ?? null;
+  let handle: AuthStateFileHandle | null = null;
+  try {
+    handle = await fs.open(filePath, fsConstants.O_RDONLY | noFollowFlag);
+    const [pathStats, handleStats] = await Promise.all([
+      fs.lstat(filePath),
+      handle.stat(),
+    ]);
+    if (pathStats.isSymbolicLink()) {
+      throw new Error(`Refusing to use symlinked auth state file: ${filePath}`);
+    }
+    if (!pathStats.isFile() || !handleStats.isFile()) {
+      throw new Error(`Auth state path is not a regular file: ${filePath}`);
+    }
+    if (!isSameFile(pathStats, handleStats)) {
+      throw new Error(`Auth state file changed while opening: ${filePath}`);
+    }
+
+    const contents = await handle.readFile({ encoding: 'utf8' });
+    await hardenAuthStateFileMode(handle);
+    return (JSON.parse(contents) as BlinkAuthState) ?? null;
+  } catch (error) {
+    if (isNodeError(error, 'ELOOP')) {
+      throw new Error(`Refusing to use symlinked auth state file: ${filePath}`);
+    }
+    throw error;
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
 }
 
 class FileAuthStorage implements BlinkAuthStorage {
@@ -115,10 +136,30 @@ class FileAuthStorage implements BlinkAuthStorage {
 
   async save(state: BlinkAuthState): Promise<void> {
     const payload = JSON.stringify(state, null, 2);
-    await fs.mkdir(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
-    await assertSafeAuthStateFilePath(this.filePath, true);
-    await fs.writeFile(this.filePath, payload, { encoding: 'utf8', mode: 0o600 });
-    await fs.chmod(this.filePath, 0o600);
+    const directory = path.dirname(this.filePath);
+    const tempPath = path.join(
+      directory,
+      `.${path.basename(this.filePath)}.${randomUUID()}.tmp`,
+    );
+    let handle: AuthStateFileHandle | null = null;
+
+    try {
+      await fs.mkdir(directory, { recursive: true, mode: 0o700 });
+      handle = await fs.open(
+        tempPath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | noFollowFlag,
+        0o600,
+      );
+      await handle.writeFile(payload, { encoding: 'utf8' });
+      await hardenAuthStateFileMode(handle);
+      await handle.close();
+      handle = null;
+      await fs.rename(tempPath, this.filePath);
+    } catch (error) {
+      await handle?.close().catch(() => undefined);
+      await fs.unlink(tempPath).catch(() => undefined);
+      throw error;
+    }
   }
 
   async clear(): Promise<void> {

--- a/src/blink-api/auth.ts
+++ b/src/blink-api/auth.ts
@@ -211,7 +211,7 @@ class FileAuthStorage implements BlinkAuthStorage {
         0o600,
       );
       await handle.writeFile(payload, { encoding: 'utf8' });
-      await hardenAuthStateFileMode(handle);
+      await hardenAuthStateFileMode(handle, tempPath);
       await handle.close();
       handle = null;
       await fs.rename(tempPath, this.filePath);

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -88,6 +88,7 @@ const LOAS_HEADER_LENGTH = 3;
 const MAX_AUDIO_BUFFER_BYTES = 256 * 1024;
 const IDLE_SHUTDOWN_GRACE_MS = 2000;
 const DEBUG_RECORDING_DIR = 'blink-stream-recordings';
+const NO_FOLLOW_FLAG = fs.constants.O_NOFOLLOW ?? 0;
 
 export interface LatmParseResult {
   frames: Buffer[];
@@ -294,7 +295,43 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       const randomSuffix = randomBytes(8).toString('hex');
       const filename = path.join(recordingDir, `blink-stream-${serialHash}-${timestamp}-${randomSuffix}.ts`);
 
-      this.streamFile = fs.createWriteStream(filename, { mode: 0o600 });
+      let recordingFd: number | null = null;
+      try {
+        recordingFd = await new Promise<number>((resolve, reject) => {
+          fs.open(
+            filename,
+            fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | NO_FOLLOW_FLAG,
+            0o600,
+            (error, fd) => {
+              if (error) {
+                reject(error);
+                return;
+              }
+              resolve(fd);
+            },
+          );
+        });
+        const currentRecordingDirStats = await fs.promises.lstat(recordingDir);
+        if (
+          currentRecordingDirStats.isSymbolicLink() ||
+          !currentRecordingDirStats.isDirectory() ||
+          currentRecordingDirStats.dev !== recordingDirStats.dev ||
+          currentRecordingDirStats.ino !== recordingDirStats.ino
+        ) {
+          throw new Error('Debug stream recording directory changed while opening recording file');
+        }
+
+        this.streamFile = fs.createWriteStream(filename, { fd: recordingFd, autoClose: true });
+        Object.defineProperty(this.streamFile, 'path', { value: filename });
+        recordingFd = null;
+      } catch (error) {
+        const fdToClose = recordingFd;
+        if (fdToClose !== null) {
+          await new Promise<void>((resolve) => fs.close(fdToClose, () => resolve()));
+        }
+        await fs.promises.unlink(filename).catch(() => undefined);
+        throw error;
+      }
       this.streamBytesWritten = 0;
 
       this.log(`Recording stream to: ${filename}`);

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -100,7 +100,17 @@ export interface LatmParseResult {
 }
 
 const isSameFsEntry = (left: FsStats, right: FsStats): boolean => {
-  return left.dev === right.dev && left.ino === right.ino;
+  return (
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.mode === right.mode &&
+    left.uid === right.uid &&
+    left.gid === right.gid &&
+    left.size === right.size &&
+    left.mtimeMs === right.mtimeMs &&
+    left.ctimeMs === right.ctimeMs &&
+    left.birthtimeMs === right.birthtimeMs
+  );
 };
 
 /**

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -16,7 +16,7 @@
 import { Buffer } from 'node:buffer';
 import { Readable } from 'node:stream';
 import { EventEmitter } from 'node:events';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as net from 'node:net';
 import * as path from 'node:path';
@@ -291,7 +291,8 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       // Create timestamped filename
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const serialHash = createHash('sha256').update(this.config.serial).digest('hex').slice(0, 16);
-      const filename = path.join(recordingDir, `blink-stream-${serialHash}-${timestamp}.ts`);
+      const randomSuffix = randomBytes(8).toString('hex');
+      const filename = path.join(recordingDir, `blink-stream-${serialHash}-${timestamp}-${randomSuffix}.ts`);
 
       this.streamFile = fs.createWriteStream(filename, { mode: 0o600 });
       this.streamBytesWritten = 0;

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -89,6 +89,8 @@ const MAX_AUDIO_BUFFER_BYTES = 256 * 1024;
 const IDLE_SHUTDOWN_GRACE_MS = 2000;
 const DEBUG_RECORDING_DIR = 'blink-stream-recordings';
 const NO_FOLLOW_FLAG = fs.constants.O_NOFOLLOW ?? 0;
+const DIRECTORY_OPEN_FLAGS = fs.constants.O_RDONLY | (fs.constants.O_DIRECTORY ?? 0) | NO_FOLLOW_FLAG;
+type FileHandle = Awaited<ReturnType<typeof fs.promises.open>>;
 
 export interface LatmParseResult {
   frames: Buffer[];
@@ -276,15 +278,17 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       return;
     }
 
+    let recordingDirHandle: FileHandle | null = null;
     try {
       const recordingDir = path.join(this.config.saveStreamPath, DEBUG_RECORDING_DIR);
       await fs.promises.mkdir(recordingDir, { recursive: true, mode: 0o700 });
-      const recordingDirStats = await fs.promises.lstat(recordingDir);
-      if (recordingDirStats.isSymbolicLink() || !recordingDirStats.isDirectory()) {
+      recordingDirHandle = await fs.promises.open(recordingDir, DIRECTORY_OPEN_FLAGS);
+      const recordingDirStats = await recordingDirHandle.stat();
+      if (!recordingDirStats.isDirectory()) {
         throw new Error('Debug stream recording directory must be a real directory');
       }
       try {
-        await fs.promises.chmod(recordingDir, 0o700);
+        await recordingDirHandle.chmod(0o700);
       } catch (error) {
         this.log(`Failed to set debug recording directory permissions: ${error}`);
       }
@@ -342,6 +346,8 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       });
     } catch (error) {
       this.log(`Failed to start stream recording: ${error}`);
+    } finally {
+      await recordingDirHandle?.close().catch(() => undefined);
     }
   }
 

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -277,6 +277,7 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     try {
       // Create directory if it doesn't exist
       await fs.promises.mkdir(this.config.saveStreamPath, { recursive: true, mode: 0o700 });
+      await fs.promises.chmod(this.config.saveStreamPath, 0o700);
 
       // Create timestamped filename
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
@@ -492,7 +493,7 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     // Client ID field (4 bytes, big-endian)
     const clientIdStr = this.parsedUrl.searchParams.get('client_id') ?? '0';
     const clientId = parseInt(clientIdStr, 10);
-    this.debug(`Client ID: ${clientId}`);
+    this.debug('Client ID: <redacted>');
     header.writeUInt32BE(clientId, offset);
     offset += 4;
 
@@ -515,7 +516,7 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     const fullConnId = pathParts[pathParts.length - 1]?.split('__')[0] ?? '';
     const connIdBytes = Buffer.alloc(CONN_ID_MAX_LENGTH);
     connIdBytes.write(fullConnId.substring(0, CONN_ID_MAX_LENGTH), 'utf-8');
-    this.debug(`Connection ID: ${fullConnId.substring(0, CONN_ID_MAX_LENGTH)}`);
+    this.debug('Connection ID: <redacted>');
     connIdBytes.copy(header, offset);
     offset += CONN_ID_MAX_LENGTH;
 

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -278,6 +278,10 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     try {
       const recordingDir = path.join(this.config.saveStreamPath, DEBUG_RECORDING_DIR);
       await fs.promises.mkdir(recordingDir, { recursive: true, mode: 0o700 });
+      const recordingDirStats = await fs.promises.lstat(recordingDir);
+      if (recordingDirStats.isSymbolicLink() || !recordingDirStats.isDirectory()) {
+        throw new Error('Debug stream recording directory must be a real directory');
+      }
       try {
         await fs.promises.chmod(recordingDir, 0o700);
       } catch (error) {

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -87,6 +87,7 @@ const LOAS_SYNCWORD_VALUE = 0xe0;
 const LOAS_HEADER_LENGTH = 3;
 const MAX_AUDIO_BUFFER_BYTES = 256 * 1024;
 const IDLE_SHUTDOWN_GRACE_MS = 2000;
+const DEBUG_RECORDING_DIR = 'blink-stream-recordings';
 
 export interface LatmParseResult {
   frames: Buffer[];
@@ -275,14 +276,14 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     }
 
     try {
-      // Create directory if it doesn't exist
-      await fs.promises.mkdir(this.config.saveStreamPath, { recursive: true, mode: 0o700 });
-      await fs.promises.chmod(this.config.saveStreamPath, 0o700);
+      const recordingDir = path.join(this.config.saveStreamPath, DEBUG_RECORDING_DIR);
+      await fs.promises.mkdir(recordingDir, { recursive: true, mode: 0o700 });
+      await fs.promises.chmod(recordingDir, 0o700);
 
       // Create timestamped filename
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
       const serialHash = createHash('sha256').update(this.config.serial).digest('hex').slice(0, 16);
-      const filename = path.join(this.config.saveStreamPath, `blink-stream-${serialHash}-${timestamp}.ts`);
+      const filename = path.join(recordingDir, `blink-stream-${serialHash}-${timestamp}.ts`);
 
       this.streamFile = fs.createWriteStream(filename, { mode: 0o600 });
       this.streamBytesWritten = 0;

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -278,7 +278,11 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     try {
       const recordingDir = path.join(this.config.saveStreamPath, DEBUG_RECORDING_DIR);
       await fs.promises.mkdir(recordingDir, { recursive: true, mode: 0o700 });
-      await fs.promises.chmod(recordingDir, 0o700);
+      try {
+        await fs.promises.chmod(recordingDir, 0o700);
+      } catch (error) {
+        this.log(`Failed to set debug recording directory permissions: ${error}`);
+      }
 
       // Create timestamped filename
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -309,6 +309,7 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       const filename = path.join(recordingDir, `blink-stream-${serialHash}-${timestamp}-${randomSuffix}.ts`);
 
       let recordingFd: number | null = null;
+      let recordingFileCreated = false;
       try {
         recordingFd = await new Promise<number>((resolve, reject) => {
           fs.open(
@@ -324,6 +325,7 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
             },
           );
         });
+        recordingFileCreated = true;
         const currentRecordingDirStats = await fs.promises.lstat(recordingDir);
         if (
           currentRecordingDirStats.isSymbolicLink() ||
@@ -342,7 +344,9 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
         if (fdToClose !== null) {
           await new Promise<void>((resolve) => fs.close(fdToClose, () => resolve()));
         }
-        await fs.promises.unlink(filename).catch(() => undefined);
+        if (recordingFileCreated) {
+          await fs.promises.unlink(filename).catch(() => undefined);
+        }
         throw error;
       }
       this.streamBytesWritten = 0;

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -100,17 +100,7 @@ export interface LatmParseResult {
 }
 
 const isSameFsEntry = (left: FsStats, right: FsStats): boolean => {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mode === right.mode &&
-    left.uid === right.uid &&
-    left.gid === right.gid &&
-    left.size === right.size &&
-    left.mtimeMs === right.mtimeMs &&
-    left.ctimeMs === right.ctimeMs &&
-    left.birthtimeMs === right.birthtimeMs
-  );
+  return left.dev === right.dev && left.ino === right.ino;
 };
 
 /**

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -16,6 +16,7 @@
 import { Buffer } from 'node:buffer';
 import { Readable } from 'node:stream';
 import { EventEmitter } from 'node:events';
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as net from 'node:net';
 import * as path from 'node:path';
@@ -38,6 +39,8 @@ export interface ImmisProxyConfig {
   debug?: boolean;
   /** Save the raw MPEG-TS stream to disk for debugging (path to save directory) */
   saveStreamPath?: string;
+  /** Verify the upstream IMMIS TLS certificate and hostname. */
+  verifyTls?: boolean;
   /**
    * Promise that resolves when the Blink command is ready.
    * The proxy will wait for this before connecting to the immis server.
@@ -182,6 +185,7 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       saveStreamPath: config.saveStreamPath,
       debug: config.debug,
       waitForReady: config.waitForReady,
+      verifyTls: config.verifyTls ?? true,
     };
 
     // If a waitForReady promise is provided, set up the ready state handler
@@ -270,13 +274,14 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
 
     try {
       // Create directory if it doesn't exist
-      fs.mkdirSync(this.config.saveStreamPath, { recursive: true });
+      fs.mkdirSync(this.config.saveStreamPath, { recursive: true, mode: 0o700 });
 
       // Create timestamped filename
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-      const filename = path.join(this.config.saveStreamPath, `blink-stream-${this.config.serial}-${timestamp}.ts`);
+      const serialHash = createHash('sha256').update(this.config.serial).digest('hex').slice(0, 16);
+      const filename = path.join(this.config.saveStreamPath, `blink-stream-${serialHash}-${timestamp}.ts`);
 
-      this.streamFile = fs.createWriteStream(filename);
+      this.streamFile = fs.createWriteStream(filename, { mode: 0o600 });
       this.streamBytesWritten = 0;
 
       this.log(`Recording stream to: ${filename}`);
@@ -409,7 +414,9 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       {
         host: hostname,
         port: port,
-        rejectUnauthorized: false, // Blink uses self-signed certs
+        rejectUnauthorized: this.config.verifyTls,
+        servername: hostname,
+        minVersion: 'TLSv1.2',
       },
       () => {
         this.log('TLS connection established');

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -243,23 +243,25 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
       });
 
       this.server.listen(this.config.port, this.config.host, () => {
-        const address = this.server!.address();
-        if (!address || typeof address === 'string') {
-          reject(new Error('Failed to get server address'));
-          return;
-        }
+        void (async () => {
+          const address = this.server!.address();
+          if (!address || typeof address === 'string') {
+            reject(new Error('Failed to get server address'));
+            return;
+          }
 
-        this.isRunning = true;
-        const url = `tcp://${address.address}:${address.port}`;
-        this.log(`Proxy server listening on ${url}`);
+          this.isRunning = true;
+          const url = `tcp://${address.address}:${address.port}`;
+          this.log(`Proxy server listening on ${url}`);
 
-        // Create stream recording file if saveStreamPath is configured
-        if (this.config.saveStreamPath) {
-          this.startStreamRecording();
-        }
+          // Create stream recording file if saveStreamPath is configured
+          if (this.config.saveStreamPath) {
+            await this.startStreamRecording();
+          }
 
-        this.emit('ready', url);
-        resolve(url);
+          this.emit('ready', url);
+          resolve(url);
+        })().catch(reject);
       });
     });
   }
@@ -267,14 +269,14 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
   /**
    * Start recording the stream to a file
    */
-  private startStreamRecording(): void {
+  private async startStreamRecording(): Promise<void> {
     if (!this.config.saveStreamPath) {
       return;
     }
 
     try {
       // Create directory if it doesn't exist
-      fs.mkdirSync(this.config.saveStreamPath, { recursive: true, mode: 0o700 });
+      await fs.promises.mkdir(this.config.saveStreamPath, { recursive: true, mode: 0o700 });
 
       // Create timestamped filename
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-');

--- a/src/blink-api/immis-proxy.ts
+++ b/src/blink-api/immis-proxy.ts
@@ -91,12 +91,17 @@ const DEBUG_RECORDING_DIR = 'blink-stream-recordings';
 const NO_FOLLOW_FLAG = fs.constants.O_NOFOLLOW ?? 0;
 const DIRECTORY_OPEN_FLAGS = fs.constants.O_RDONLY | (fs.constants.O_DIRECTORY ?? 0) | NO_FOLLOW_FLAG;
 type FileHandle = Awaited<ReturnType<typeof fs.promises.open>>;
+type FsStats = Awaited<ReturnType<typeof fs.promises.lstat>>;
 
 export interface LatmParseResult {
   frames: Buffer[];
   remainder: Buffer;
   discardedBytes: number;
 }
+
+const isSameFsEntry = (left: FsStats, right: FsStats): boolean => {
+  return left.dev === right.dev && left.ino === right.ino;
+};
 
 /**
  * Extract LOAS/LATM frames from a buffer.
@@ -282,10 +287,14 @@ export class ImmisProxyServer extends EventEmitter<ImmisProxyEvents> {
     try {
       const recordingDir = path.join(this.config.saveStreamPath, DEBUG_RECORDING_DIR);
       await fs.promises.mkdir(recordingDir, { recursive: true, mode: 0o700 });
+      const recordingDirPathStats = await fs.promises.lstat(recordingDir);
+      if (recordingDirPathStats.isSymbolicLink() || !recordingDirPathStats.isDirectory()) {
+        throw new Error('Debug stream recording directory must be a real directory');
+      }
       recordingDirHandle = await fs.promises.open(recordingDir, DIRECTORY_OPEN_FLAGS);
       const recordingDirStats = await recordingDirHandle.stat();
-      if (!recordingDirStats.isDirectory()) {
-        throw new Error('Debug stream recording directory must be a real directory');
+      if (!recordingDirStats.isDirectory() || !isSameFsEntry(recordingDirPathStats, recordingDirStats)) {
+        throw new Error('Debug stream recording directory changed while opening');
       }
       try {
         await recordingDirHandle.chmod(0o700);

--- a/src/homebridge-ui/auth-state.ts
+++ b/src/homebridge-ui/auth-state.ts
@@ -3,6 +3,7 @@ import {
   readPersistedAuthStateFile,
 } from '../blink-api/auth';
 import { BlinkAuthState } from '../types';
+import * as path from 'node:path';
 
 export interface PersistedAuthStateLoadResult {
   state: BlinkAuthState | null;
@@ -17,6 +18,14 @@ const describeError = (error: unknown): string => {
   return error instanceof Error ? error.message : 'Unknown error';
 };
 
+const describeUiFilePath = (filePath: string): string => {
+  return path.basename(filePath) || 'auth state file';
+};
+
+const describeUiError = (error: unknown, filePath: string): string => {
+  return describeError(error).split(filePath).join(describeUiFilePath(filePath));
+};
+
 export async function loadPersistedAuthStateFromFiles(
   filePaths: string[],
   logDebug: (message: string) => void,
@@ -25,24 +34,29 @@ export async function loadPersistedAuthStateFromFiles(
   let ignoredMessage: string | undefined;
 
   for (const filePath of filePaths) {
+    const uiFilePath = describeUiFilePath(filePath);
     try {
       const state = await readPersistedAuthStateFile(filePath);
       if (!state?.accessToken) {
-        ignoredMessage = `Persisted Blink authentication was ignored: ${filePath} does not contain an access token`;
-        logDebug(ignoredMessage);
+        ignoredMessage = `Persisted Blink authentication was ignored: ${uiFilePath} does not contain an access token`;
+        logDebug(`Persisted Blink authentication was ignored: ${filePath} does not contain an access token`);
         continue;
       }
       if (state.tokenExpiry) {
         const expiry = new Date(state.tokenExpiry);
         const expiryMs = expiry.getTime();
         if (Number.isNaN(expiryMs)) {
-          ignoredMessage = `Persisted Blink authentication was ignored: saved token at ${filePath} has invalid expiry ${state.tokenExpiry}`;
-          logDebug(ignoredMessage);
+          ignoredMessage = `Persisted Blink authentication was ignored: saved token in ${uiFilePath} has invalid expiry ${state.tokenExpiry}`;
+          logDebug(
+            `Persisted Blink authentication was ignored: saved token at ${filePath} has invalid expiry ${state.tokenExpiry}`,
+          );
           continue;
         }
         if (expiryMs <= nowMs()) {
-          ignoredMessage = `Persisted Blink authentication was ignored: saved token at ${filePath} expired at ${state.tokenExpiry}`;
-          logDebug(ignoredMessage);
+          ignoredMessage = `Persisted Blink authentication was ignored: saved token in ${uiFilePath} expired at ${state.tokenExpiry}`;
+          logDebug(
+            `Persisted Blink authentication was ignored: saved token at ${filePath} expired at ${state.tokenExpiry}`,
+          );
           continue;
         }
       }
@@ -54,13 +68,13 @@ export async function loadPersistedAuthStateFromFiles(
       }
 
       if (error instanceof AuthStateFileSecurityError) {
-        const message = `Persisted Blink authentication was ignored: ${error.message}`;
-        logDebug(message);
+        const message = `Persisted Blink authentication was ignored: ${describeUiError(error, filePath)}`;
+        logDebug(`Persisted Blink authentication was ignored: ${error.message}`);
         return { state: null, message };
       }
 
-      ignoredMessage = `Persisted Blink authentication was ignored: failed to read ${filePath}: ${describeError(error)}`;
-      logDebug(ignoredMessage);
+      ignoredMessage = `Persisted Blink authentication was ignored: failed to read ${uiFilePath}: ${describeUiError(error, filePath)}`;
+      logDebug(`Persisted Blink authentication was ignored: failed to read ${filePath}: ${describeError(error)}`);
     }
   }
   return { state: null, message: ignoredMessage };

--- a/src/homebridge-ui/auth-state.ts
+++ b/src/homebridge-ui/auth-state.ts
@@ -34,7 +34,13 @@ export async function loadPersistedAuthStateFromFiles(
       }
       if (state.tokenExpiry) {
         const expiry = new Date(state.tokenExpiry);
-        if (!Number.isNaN(expiry.getTime()) && expiry.getTime() <= nowMs()) {
+        const expiryMs = expiry.getTime();
+        if (Number.isNaN(expiryMs)) {
+          ignoredMessage = `Persisted Blink authentication was ignored: saved token at ${filePath} has invalid expiry ${state.tokenExpiry}`;
+          logDebug(ignoredMessage);
+          continue;
+        }
+        if (expiryMs <= nowMs()) {
           ignoredMessage = `Persisted Blink authentication was ignored: saved token at ${filePath} expired at ${state.tokenExpiry}`;
           logDebug(ignoredMessage);
           continue;

--- a/src/homebridge-ui/auth-state.ts
+++ b/src/homebridge-ui/auth-state.ts
@@ -22,14 +22,21 @@ export async function loadPersistedAuthStateFromFiles(
   logDebug: (message: string) => void,
   nowMs = Date.now,
 ): Promise<PersistedAuthStateLoadResult> {
+  let ignoredMessage: string | undefined;
+
   for (const filePath of filePaths) {
     try {
       const state = await readPersistedAuthStateFile(filePath);
-      if (!state?.accessToken) continue;
+      if (!state?.accessToken) {
+        ignoredMessage = `Persisted Blink authentication was ignored: ${filePath} does not contain an access token`;
+        logDebug(ignoredMessage);
+        continue;
+      }
       if (state.tokenExpiry) {
         const expiry = new Date(state.tokenExpiry);
         if (!Number.isNaN(expiry.getTime()) && expiry.getTime() <= nowMs()) {
-          logDebug(`Persisted auth state at ${filePath} has expired token; skipping`);
+          ignoredMessage = `Persisted Blink authentication was ignored: saved token at ${filePath} expired at ${state.tokenExpiry}`;
+          logDebug(ignoredMessage);
           continue;
         }
       }
@@ -46,8 +53,9 @@ export async function loadPersistedAuthStateFromFiles(
         return { state: null, message };
       }
 
-      logDebug(`Failed to read persisted auth state from ${filePath}: ${describeError(error)}`);
+      ignoredMessage = `Persisted Blink authentication was ignored: failed to read ${filePath}: ${describeError(error)}`;
+      logDebug(ignoredMessage);
     }
   }
-  return { state: null };
+  return { state: null, message: ignoredMessage };
 }

--- a/src/homebridge-ui/auth-state.ts
+++ b/src/homebridge-ui/auth-state.ts
@@ -1,0 +1,53 @@
+import {
+  AuthStateFileSecurityError,
+  readPersistedAuthStateFile,
+} from '../blink-api/auth';
+import { BlinkAuthState } from '../types';
+
+export interface PersistedAuthStateLoadResult {
+  state: BlinkAuthState | null;
+  message?: string;
+}
+
+const isNodeError = (error: unknown, code: string): boolean => {
+  return (error as { code?: string }).code === code;
+};
+
+const describeError = (error: unknown): string => {
+  return error instanceof Error ? error.message : 'Unknown error';
+};
+
+export async function loadPersistedAuthStateFromFiles(
+  filePaths: string[],
+  logDebug: (message: string) => void,
+  nowMs = Date.now,
+): Promise<PersistedAuthStateLoadResult> {
+  for (const filePath of filePaths) {
+    try {
+      const state = await readPersistedAuthStateFile(filePath);
+      if (!state?.accessToken) continue;
+      if (state.tokenExpiry) {
+        const expiry = new Date(state.tokenExpiry);
+        if (!Number.isNaN(expiry.getTime()) && expiry.getTime() <= nowMs()) {
+          logDebug(`Persisted auth state at ${filePath} has expired token; skipping`);
+          continue;
+        }
+      }
+      logDebug(`Loaded valid persisted auth state from ${filePath}`);
+      return { state };
+    } catch (error) {
+      if (isNodeError(error, 'ENOENT')) {
+        continue;
+      }
+
+      if (error instanceof AuthStateFileSecurityError) {
+        const message = `Persisted Blink authentication was ignored: ${error.message}`;
+        logDebug(message);
+        return { state: null, message };
+      }
+
+      logDebug(`Failed to read persisted auth state from ${filePath}: ${describeError(error)}`);
+    }
+  }
+  return { state: null };
+}

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -15,10 +15,10 @@ import { HomebridgePluginUiServer, RequestError } from '@homebridge/plugin-ui-ut
 import {
   Blink2FARequiredError,
   BlinkAuthenticationError,
-  readPersistedAuthStateFile,
 } from '../blink-api/auth';
 import { BlinkApi } from '../blink-api/client';
-import { BlinkAuthState, BlinkConfig, BlinkLogger } from '../types';
+import { BlinkConfig, BlinkLogger } from '../types';
+import { loadPersistedAuthStateFromFiles } from './auth-state';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
@@ -413,7 +413,7 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    */
   async handleStatus(): Promise<AuthStatus> {
     if (!this.authStatus.authenticated) {
-      const diskState = await this.loadPersistedAuthState();
+      const { state: diskState, message } = await this.loadPersistedAuthState();
       if (diskState) {
         this.authStatus = {
           authenticated: true,
@@ -421,6 +421,11 @@ class BlinkUiServer extends HomebridgePluginUiServer {
           accountId: diskState.accountId ?? undefined,
           tier: diskState.tier ?? undefined,
           message: 'Restored from persisted auth state',
+        };
+      } else if (message) {
+        this.authStatus = {
+          authenticated: false,
+          message,
         };
       }
     }
@@ -431,26 +436,12 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    * Read the on-disk .blink-auth.json (or legacy blink-auth/auth-state.json)
    * and return it if it looks valid (has an access token and is not expired).
    */
-  private async loadPersistedAuthState(): Promise<BlinkAuthState | null> {
+  private async loadPersistedAuthState(): Promise<ReturnType<typeof loadPersistedAuthStateFromFiles>> {
     // Try primary dot-file first, then fall back to legacy subdirectory path
-    for (const filePath of [this.getAuthStoragePath(), this.getLegacyAuthStoragePath()]) {
-      try {
-        const state = await readPersistedAuthStateFile(filePath);
-        if (!state?.accessToken) continue;
-        if (state.tokenExpiry) {
-          const expiry = new Date(state.tokenExpiry);
-          if (!Number.isNaN(expiry.getTime()) && expiry.getTime() <= Date.now()) {
-            this.logDebug(`Persisted auth state at ${filePath} has expired token; skipping`);
-            continue;
-          }
-        }
-        this.logDebug(`Loaded valid persisted auth state from ${filePath}`);
-        return state;
-      } catch {
-        // File doesn't exist or is unreadable — try next
-      }
-    }
-    return null;
+    return loadPersistedAuthStateFromFiles(
+      [this.getAuthStoragePath(), this.getLegacyAuthStoragePath()],
+      this.logDebug.bind(this),
+    );
   }
 
   private async clearPersistedAuthState(): Promise<void> {

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -425,7 +425,7 @@ class BlinkUiServer extends HomebridgePluginUiServer {
           tier: diskState.tier ?? undefined,
           message: 'Restored from persisted auth state',
         };
-      } else if (message) {
+      } else if (message && this.canShowPersistedAuthMessage()) {
         this.authStatus = {
           authenticated: false,
           message,
@@ -433,6 +433,13 @@ class BlinkUiServer extends HomebridgePluginUiServer {
       }
     }
     return this.authStatus;
+  }
+
+  private canShowPersistedAuthMessage(): boolean {
+    return !this.authStatus.message &&
+      !this.authStatus.requires2FA &&
+      !this.authStatus.requiresClientVerification &&
+      !this.authStatus.requiresAccountVerification;
   }
 
   /**

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -18,7 +18,10 @@ import {
 } from '../blink-api/auth';
 import { BlinkApi } from '../blink-api/client';
 import { BlinkConfig, BlinkLogger } from '../types';
-import { loadPersistedAuthStateFromFiles } from './auth-state';
+import {
+  loadPersistedAuthStateFromFiles,
+  type PersistedAuthStateLoadResult,
+} from './auth-state';
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
@@ -436,7 +439,7 @@ class BlinkUiServer extends HomebridgePluginUiServer {
    * Read the on-disk .blink-auth.json (or legacy blink-auth/auth-state.json)
    * and return it if it looks valid (has an access token and is not expired).
    */
-  private async loadPersistedAuthState(): Promise<ReturnType<typeof loadPersistedAuthStateFromFiles>> {
+  private async loadPersistedAuthState(): Promise<PersistedAuthStateLoadResult> {
     // Try primary dot-file first, then fall back to legacy subdirectory path
     return loadPersistedAuthStateFromFiles(
       [this.getAuthStoragePath(), this.getLegacyAuthStoragePath()],

--- a/src/homebridge-ui/server.ts
+++ b/src/homebridge-ui/server.ts
@@ -12,7 +12,11 @@
  */
 
 import { HomebridgePluginUiServer, RequestError } from '@homebridge/plugin-ui-utils';
-import { Blink2FARequiredError, BlinkAuthenticationError } from '../blink-api/auth';
+import {
+  Blink2FARequiredError,
+  BlinkAuthenticationError,
+  readPersistedAuthStateFile,
+} from '../blink-api/auth';
 import { BlinkApi } from '../blink-api/client';
 import { BlinkAuthState, BlinkConfig, BlinkLogger } from '../types';
 import { promises as fs } from 'node:fs';
@@ -431,8 +435,7 @@ class BlinkUiServer extends HomebridgePluginUiServer {
     // Try primary dot-file first, then fall back to legacy subdirectory path
     for (const filePath of [this.getAuthStoragePath(), this.getLegacyAuthStoragePath()]) {
       try {
-        const raw = await fs.readFile(filePath, 'utf8');
-        const state = JSON.parse(raw) as BlinkAuthState;
+        const state = await readPersistedAuthStateFile(filePath);
         if (!state?.accessToken) continue;
         if (state.tokenExpiry) {
           const expiry = new Date(state.tokenExpiry);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -83,6 +83,7 @@ interface BlinkPlatformConfig extends PlatformConfig {
   audioBitrate?: number;
   videoBitrate?: number;
   videoEncoder?: VideoEncoderPreference;
+  verifyImmisTls?: boolean;
   debugAuth?: boolean;
   authLocked?: boolean;
   debugStreamPath?: string;
@@ -135,6 +136,7 @@ export class BlinkCamerasPlatform implements DynamicPlatformPlugin {
       rtspTransport: this.config.rtspTransport,
       maxStreams: this.config.maxStreams,
       debugStreamPath: this.config.debugStreamPath,
+      verifyImmisTls: this.config.verifyImmisTls,
       snapshotCacheTTL: this.config.snapshotCacheTTL,
       persistSnapshotCache: this.config.persistSnapshotCache,
       audio: {


### PR DESCRIPTION
## Description

Hardens the login/auth persistence and live streaming paths after a focused security audit of token storage, the IMMIS proxy, FFmpeg invocation/logging, and debug stream recording.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test updates
- [x] Build/CI updates

## Changes Made

- Enables upstream IMMIS TLS certificate and hostname verification by default, with a documented opt-out for constrained setups.
- Redacts IMMIS/RTSP live stream URLs and SRTP parameters from stream logs while preserving the raw FFmpeg spawn arguments.
- Hardens persisted auth-token file permissions on save and load, including fail-closed POSIX handling when shared-readable auth files cannot be tightened.
- Reports rejected persisted auth state in the Homebridge UI status response, including expired, malformed, invalid-expiry, missing-token, and security-rejected files.
- Hardens debug stream recording permissions and filenames, verifying directory identity before handle-based chmod and before capture file use.
- Avoids deleting pre-existing debug recording files when exclusive capture-file creation fails before this attempt creates the file.
- Enforces stream concurrency before requesting a Blink live-view session.
- Adds focused auth, UI auth-state, IMMIS proxy, accessory streaming, and schema tests.
- Updates the audit report, streaming/debug logging documentation, and dependency lockfile after clearing dev audit findings.

## Testing

- [x] I have tested these changes locally
- [x] I have added new tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

Fresh local checks on `codex/auth-streaming-security-hardening`:

- `npm test -- --runInBand` - 14 suites / 104 tests passed
- `npm run build` - passed
- `npm run lint` - passed
- `npm audit --json` - 0 vulnerabilities

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Related Issues

Beads: `homebridge-blinkcameras-3vq`, `homebridge-blinkcameras-yvo`, partial streaming follow-up context in `hb-blinkcameras-9cs`.

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Full HomeKit live-view reproduction on real hardware was not performed in this audit/remediation pass; that remains tracked separately in Beads.


